### PR TITLE
explicitly cast createTypeUnsafe to Market

### DIFF
--- a/chain/prediction-markets.ts
+++ b/chain/prediction-markets.ts
@@ -26,9 +26,9 @@ export namespace PredictionMarkets {
         createTypeUnsafe<MarketIdOf & Codec>(typeRegistry, "MarketIdOf", [
           this.ctx.params[0].value,
         ]),
-        createTypeUnsafe<Market & Codec>(typeRegistry, "Market", [
+        (createTypeUnsafe<Market & Codec>(typeRegistry, "Market", [
           this.ctx.params[1].value,
-        ]),
+        ]) as any) as Market,
         createTypeUnsafe<AccountId & Codec>(typeRegistry, "AccountId", [
           this.ctx.params[2].value,
         ]),


### PR DESCRIPTION
The `Market` type doesn's seem to work properly with `DetectType` alias from polkadot.js https://github.com/polkadot-js/api/blob/f6e50f14b5301e8ba23eec0e9059c544de2552ea/packages/types/src/types/detect.ts#L10