### PR TITLE
Execute DustLostEvent after ExtrinsicSuccessEvent

### DIFF
--- a/mappings/balances.ts
+++ b/mappings/balances.ts
@@ -552,20 +552,23 @@ export async function systemNewAccount({
     const [accountId] = new System.NewAccountEvent(event).params
     const walletId = encodeAddress(accountId, (await Tools.getSDK()).api.consts.system.ss58Prefix.toNumber())
     
-    const acc = new Account()
-    acc.wallet = walletId
-    console.log(`[${event.method}] Saving account: ${JSON.stringify(acc, null, 2)}`)
-    await store.save<Account>(acc)
+    const acc = await store.get(Account, { where: { wallet: walletId } })
+    if (acc) return
+
+    const newAcc = new Account()
+    newAcc.wallet = walletId
+    console.log(`[${event.method}] Saving account: ${JSON.stringify(newAcc, null, 2)}`)
+    await store.save<Account>(newAcc)
 
     const ab = new AssetBalance()
-    ab.account = acc
+    ab.account = newAcc
     ab.assetId = "Ztg"
     ab.balance = new BN(0)
     console.log(`[${event.method}] Saving asset balance: ${JSON.stringify(ab, null, 2)}`)
     await store.save<AssetBalance>(ab)
 
     const hab = new HistoricalAssetBalance()
-    hab.account = acc
+    hab.account = newAcc
     hab.event = event.method
     hab.assetId = ab.assetId
     hab.amount = new BN(0)

--- a/mappings/balances.ts
+++ b/mappings/balances.ts
@@ -615,6 +615,26 @@ export async function systemExtrinsicSuccess({
         hab.timestamp = new BN(block.timestamp)
         console.log(`[${event.method}] Saving historical asset balance: ${JSON.stringify(hab, null, 2)}`)
         await store.save<HistoricalAssetBalance>(hab)
+
+        const dhab = await store.get(HistoricalAssetBalance, { where: 
+            { account: acc, assetId: "Ztg", event: "DustLost", blockNumber: block.height } })
+        if (dhab) {
+            ab.balance = ab.balance.sub(dhab.amount)
+
+            const hab = new HistoricalAssetBalance()
+            hab.account = acc
+            hab.event = dhab.event
+            hab.assetId = ab.assetId
+            hab.amount = new BN(0 - dhab.amount.toNumber())
+            hab.balance = ab.balance
+            hab.blockNumber = block.height
+            hab.timestamp = new BN(block.timestamp)
+            console.log(`[${event.method}] Saving historical asset balance: ${JSON.stringify(hab, null, 2)}`)
+            await store.save<HistoricalAssetBalance>(hab)
+
+            console.log(`[${event.method}] Removing historical asset balance: ${JSON.stringify(dhab, null, 2)}`)
+            await store.remove<HistoricalAssetBalance>(dhab)
+        }
     }
 }
 


### PR DESCRIPTION
At the block, the event `balances.DustLost` comes before `balances.Transfer` and `system.ExtrinsicSuccess` when the account balance goes below `ExistentialDeposit`. Following this sequence while computing Ztg balance for the account would result in negative balance (as observed for few accounts).

The `DustLostEvent` should technically be captured for the account when the amount is transferred and transaction fees is incurred for executing the transfer from the the same account.