### PR TITLE
Remove recursive ref for account balances

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,7 +1,6 @@
 type Account @entity {
   "Account address"
   wallet: String!
-  accountBalances: [AccountBalance] @derivedFrom(field: "account")
 }
 
 type AccountBalance @entity {

--- a/src/model/generated/account.model.ts
+++ b/src/model/generated/account.model.ts
@@ -1,5 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, OneToMany as OneToMany_} from "typeorm"
-import {AccountBalance} from "./accountBalance.model"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_} from "typeorm"
 
 @Entity_()
 export class Account {
@@ -15,7 +14,4 @@ export class Account {
    */
   @Column_("text", {nullable: false})
   wallet!: string
-
-  @OneToMany_(() => AccountBalance, e => e.account)
-  accountBalances!: AccountBalance[]
 }


### PR DESCRIPTION
Using `@derivedFrom` annotation while nesting entities in an entity creates recursive references which gets prone to manual attacks by any user as discussed in #63.

Avoiding them would help in processing query requests with much ease.