### PR TITLE
Manually fix balances to record activity unavailable via event/extrinsic data

### DIFF
--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -6,6 +6,7 @@ import { predictionMarketApproved, predictionMarketBoughtCompleteSet, prediction
     predictionMarketCreated, predictionMarketDisputed, predictionMarketInsufficientSubsidy, 
     predictionMarketRejected, predictionMarketReported, predictionMarketResolved, 
     predictionMarketSoldCompleteSet, predictionMarketStartedWithSubsidy } from "./markets";
+import { add_balance_108949, add_balance_155917 } from "./postHooks";
 import { swapExactAmountIn, swapExactAmountOut, swapPoolCreated, swapPoolExited, swapPoolJoined } from "./swaps";
 
 (BigInt.prototype as any).toJSON = function () {
@@ -50,5 +51,8 @@ processor.addEventHandler('swaps.PoolExit', swapPoolExited)
 processor.addEventHandler('swaps.PoolJoin', swapPoolJoined)
 processor.addEventHandler('swaps.SwapExactAmountIn', swapExactAmountIn)
 processor.addEventHandler('swaps.SwapExactAmountOut', swapExactAmountOut)
+
+processor.addPostHook({range: {from: 108949, to: 108949}}, add_balance_108949)
+processor.addPostHook({range: {from: 155917, to: 155917}}, add_balance_155917)
 
 processor.run()

--- a/src/processor/postHooks.ts
+++ b/src/processor/postHooks.ts
@@ -1,0 +1,68 @@
+import { BlockHandlerContext } from "@subsquid/substrate-processor"
+import { Account, AccountBalance, HistoricalAccountBalance } from "../model"
+
+export async function add_balance_108949(ctx: BlockHandlerContext) {
+    const {store, events, block} = ctx
+    for (var i = 0; i < events.length; i++) {
+        const event = events[i]
+        if (event.name == "balances.Unreserved") {
+            const walletId = "dE1EyDwADmoUReAUN2ynVgvGmqkmaWj3Ht1hMndubRPY4NrjD"
+
+            const acc = await store.get(Account, { where: { wallet: walletId } })
+            if (!acc) { return }
+
+            const ab = await store.get(AccountBalance, { where: { account: acc, assetId: "Ztg" } })
+            if (ab) {
+                ab.balance = ab.balance + BigInt(5000000000)
+                console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`)
+                await store.save<AccountBalance>(ab)
+
+                const hab = new HistoricalAccountBalance()
+                hab.id = event.id + '-' + walletId.substring(walletId.length - 5)
+                hab.accountId = acc.wallet
+                hab.event = "PostHook"
+                hab.assetId = ab.assetId
+                hab.amount = BigInt(5000000000)
+                hab.balance = ab.balance
+                hab.blockNumber = block.height
+                hab.timestamp = new Date(block.timestamp)
+                console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`)
+                await store.save<HistoricalAccountBalance>(hab)
+            }
+            break
+        }
+    }
+}
+
+export async function add_balance_155917(ctx: BlockHandlerContext) {
+    const {store, events, block} = ctx
+    for (var i = 0; i < events.length; i++) {
+        const event = events[i]
+        if (event.name == "balances.Unreserved") {
+            const walletId = "dE4NbK6XC4dJEkjU5erpDNj2ydMh1fMNw8ug7xNgzTxqFo5iW"
+
+            const acc = await store.get(Account, { where: { wallet: walletId } })
+            if (!acc) { return }
+
+            const ab = await store.get(AccountBalance, { where: { account: acc, assetId: "Ztg" } })
+            if (ab) {
+                ab.balance = ab.balance + BigInt(5000000000)
+                console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`)
+                await store.save<AccountBalance>(ab)
+
+                const hab = new HistoricalAccountBalance()
+                hab.id = event.id + '-' + walletId.substring(walletId.length - 5)
+                hab.accountId = acc.wallet
+                hab.event = "PostHook"
+                hab.assetId = ab.assetId
+                hab.amount = BigInt(5000000000)
+                hab.balance = ab.balance
+                hab.blockNumber = block.height
+                hab.timestamp = new Date(block.timestamp)
+                console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`)
+                await store.save<HistoricalAccountBalance>(hab)
+            }
+            break
+        }
+    }
+}


### PR DESCRIPTION
As discussed at https://github.com/zeitgeistpm/zeitgeist/issues/444

This PR sets a stage for post block hooks in order to manually consider data which hasn't been recorded by any event.