### PR TITLE
Remove environment variable BLOCK_ZERO

### DIFF
--- a/.env
+++ b/.env
@@ -4,9 +4,6 @@ PROJECT_NAME=zeitgeist-squid
 WS_NODE_URL=wss://bsr.zeitgeist.pm
 # WS_NODE_URL=ws://localhost:9944
 
-# Block Info
-BLOCK_ZERO=0xb90cd3a37b4793c6494b78962986f4f6ed3ec2eda91a6b84fd8457d24f606b9c
-
 ###########################
 #     Common settings     #
 ###########################

--- a/src/processor/balances.ts
+++ b/src/processor/balances.ts
@@ -633,8 +633,13 @@ export async function currencyWithdrawn(ctx: EventHandlerContext) {
 
 async function initBalance(acc: Account, store: Store, event: SubstrateEvent, block: SubstrateBlock) {
     const sdk = await Tools.getSDK()
-    const blockZero = process.env.BLOCK_ZERO!
-    const { data : { free: amt } } = await sdk.api.query.system.account.at(blockZero, acc.accountId) as AccountInfo
+    const blockZero = await sdk.api.rpc.chain.getBlockHash(0);
+    const {
+      data: { free: amt },
+    } = (await sdk.api.query.system.account.at(
+      blockZero,
+      acc.accountId
+    )) as AccountInfo;
 
     const ab = new AccountBalance()
     ab.id = event.id + '-' + acc.accountId.substring(acc.accountId.length - 5)


### PR DESCRIPTION
it's used only in `initBalance` as I see, could be wrong, but if that's the case it can be replaced with an rpc call to sdk.

This also helps when indexing different node, e.g. local node