### PR TITLE
Reconcile balances before `zeitgeist:0.2.4`

### DIFF
--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -6,7 +6,8 @@ import { predictionMarketApproved, predictionMarketBoughtCompleteSet, prediction
     predictionMarketCreated, predictionMarketDisputed, predictionMarketInsufficientSubsidy, 
     predictionMarketRejected, predictionMarketReported, predictionMarketResolved, 
     predictionMarketSoldCompleteSet, predictionMarketStartedWithSubsidy } from "./markets";
-import { add_balance_108949, add_balance_155917, add_balance_175178 } from "./postHooks";
+import { add_balance_108949, add_balance_155917, add_balance_175178, add_balance_178290, add_balance_179524, 
+  add_balance_184820, add_balance_204361 } from "./postHooks";
 import { swapExactAmountIn, swapExactAmountOut, swapPoolCreated, swapPoolExited, swapPoolJoined } from "./swaps";
 
 (BigInt.prototype as any).toJSON = function () {
@@ -58,5 +59,9 @@ processor.addEventHandler('swaps.SwapExactAmountOut', swapExactAmountOut)
 processor.addPostHook({range: {from: 108949, to: 108949}}, add_balance_108949)
 processor.addPostHook({range: {from: 155917, to: 155917}}, add_balance_155917)
 processor.addPostHook({range: {from: 175178, to: 175178}}, add_balance_175178)
+processor.addPostHook({range: {from: 178290, to: 178290}}, add_balance_178290)
+processor.addPostHook({range: {from: 179524, to: 179524}}, add_balance_179524)
+processor.addPostHook({range: {from: 184820, to: 184820}}, add_balance_184820)
+processor.addPostHook({range: {from: 204361, to: 204361}}, add_balance_204361)
 
 processor.run()

--- a/src/processor/postHooks.ts
+++ b/src/processor/postHooks.ts
@@ -164,3 +164,44 @@ export async function add_balance_178290(ctx: BlockHandlerContext) {
         }
     }
 }
+
+export async function add_balance_179524(ctx: BlockHandlerContext) {
+    const {store, events, block} = ctx
+    for (var i = 0; i < events.length; i++) {
+        const event = events[i]
+        if (event.name == "balances.Unreserved") {
+            const walletId = "dE4NbK6XC4dJEkjU5erpDNj2ydMh1fMNw8ug7xNgzTxqFo5iW"
+
+            const acc = await store.get(Account, { where: { accountId: walletId } })
+            if (!acc) { return }
+
+            const ab = await store.get(AccountBalance, { where: { account: acc, assetId: "Ztg" } })
+            if (ab) {
+                ab.balance = ab.balance + BigInt(50000000000)
+                ab.value = Number(ab.balance)
+                console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`)
+                await store.save<AccountBalance>(ab)
+
+                acc.pvalue = acc.pvalue + 50000000000
+                console.log(`[${event.name}] Saving account: ${JSON.stringify(acc, null, 2)}`)
+                await store.save<Account>(acc)
+
+                const hab = new HistoricalAccountBalance()
+                hab.id = event.id + '-' + walletId.substring(walletId.length - 5)
+                hab.accountId = acc.accountId
+                hab.event = "PostHook"
+                hab.assetId = ab.assetId
+                hab.dBalance = BigInt(50000000000)
+                hab.balance = ab.balance
+                hab.dValue = Number(hab.dBalance)
+                hab.value = Number(hab.balance)
+                hab.pvalue = acc.pvalue
+                hab.blockNumber = block.height
+                hab.timestamp = new Date(block.timestamp)
+                console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`)
+                await store.save<HistoricalAccountBalance>(hab)
+            }
+            break
+        }
+    }
+}

--- a/src/processor/postHooks.ts
+++ b/src/processor/postHooks.ts
@@ -123,3 +123,44 @@ export async function add_balance_175178(ctx: BlockHandlerContext) {
         }
     }
 }
+
+export async function add_balance_178290(ctx: BlockHandlerContext) {
+    const {store, events, block} = ctx
+    for (var i = 0; i < events.length; i++) {
+        const event = events[i]
+        if (event.name == "balances.Unreserved") {
+            const walletId = "dE4NbK6XC4dJEkjU5erpDNj2ydMh1fMNw8ug7xNgzTxqFo5iW"
+
+            const acc = await store.get(Account, { where: { accountId: walletId } })
+            if (!acc) { return }
+
+            const ab = await store.get(AccountBalance, { where: { account: acc, assetId: "Ztg" } })
+            if (ab) {
+                ab.balance = ab.balance + BigInt(50000000000)
+                ab.value = Number(ab.balance)
+                console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`)
+                await store.save<AccountBalance>(ab)
+
+                acc.pvalue = acc.pvalue + 50000000000
+                console.log(`[${event.name}] Saving account: ${JSON.stringify(acc, null, 2)}`)
+                await store.save<Account>(acc)
+
+                const hab = new HistoricalAccountBalance()
+                hab.id = event.id + '-' + walletId.substring(walletId.length - 5)
+                hab.accountId = acc.accountId
+                hab.event = "PostHook"
+                hab.assetId = ab.assetId
+                hab.dBalance = BigInt(50000000000)
+                hab.balance = ab.balance
+                hab.dValue = Number(hab.dBalance)
+                hab.value = Number(hab.balance)
+                hab.pvalue = acc.pvalue
+                hab.blockNumber = block.height
+                hab.timestamp = new Date(block.timestamp)
+                console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`)
+                await store.save<HistoricalAccountBalance>(hab)
+            }
+            break
+        }
+    }
+}

--- a/src/processor/postHooks.ts
+++ b/src/processor/postHooks.ts
@@ -246,3 +246,44 @@ export async function add_balance_184820(ctx: BlockHandlerContext) {
         }
     }
 }
+
+export async function add_balance_204361(ctx: BlockHandlerContext) {
+    const {store, events, block} = ctx
+    for (var i = 0; i < events.length; i++) {
+        const event = events[i]
+        if (event.name == "balances.Unreserved") {
+            const walletId = "dE4NbK6XC4dJEkjU5erpDNj2ydMh1fMNw8ug7xNgzTxqFo5iW"
+
+            const acc = await store.get(Account, { where: { accountId: walletId } })
+            if (!acc) { return }
+
+            const ab = await store.get(AccountBalance, { where: { account: acc, assetId: "Ztg" } })
+            if (ab) {
+                ab.balance = ab.balance + BigInt(82500000000)
+                ab.value = Number(ab.balance)
+                console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`)
+                await store.save<AccountBalance>(ab)
+
+                acc.pvalue = acc.pvalue + 82500000000
+                console.log(`[${event.name}] Saving account: ${JSON.stringify(acc, null, 2)}`)
+                await store.save<Account>(acc)
+
+                const hab = new HistoricalAccountBalance()
+                hab.id = event.id + '-' + walletId.substring(walletId.length - 5)
+                hab.accountId = acc.accountId
+                hab.event = "PostHook"
+                hab.assetId = ab.assetId
+                hab.dBalance = BigInt(82500000000)
+                hab.balance = ab.balance
+                hab.dValue = Number(hab.dBalance)
+                hab.value = Number(hab.balance)
+                hab.pvalue = acc.pvalue
+                hab.blockNumber = block.height
+                hab.timestamp = new Date(block.timestamp)
+                console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`)
+                await store.save<HistoricalAccountBalance>(hab)
+            }
+            break
+        }
+    }
+}

--- a/src/processor/postHooks.ts
+++ b/src/processor/postHooks.ts
@@ -205,3 +205,44 @@ export async function add_balance_179524(ctx: BlockHandlerContext) {
         }
     }
 }
+
+export async function add_balance_184820(ctx: BlockHandlerContext) {
+    const {store, events, block} = ctx
+    for (var i = 0; i < events.length; i++) {
+        const event = events[i]
+        if (event.name == "balances.Unreserved") {
+            const walletId = "dE4NbK6XC4dJEkjU5erpDNj2ydMh1fMNw8ug7xNgzTxqFo5iW"
+
+            const acc = await store.get(Account, { where: { accountId: walletId } })
+            if (!acc) { return }
+
+            const ab = await store.get(AccountBalance, { where: { account: acc, assetId: "Ztg" } })
+            if (ab) {
+                ab.balance = ab.balance + BigInt(50000000000)
+                ab.value = Number(ab.balance)
+                console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`)
+                await store.save<AccountBalance>(ab)
+
+                acc.pvalue = acc.pvalue + 50000000000
+                console.log(`[${event.name}] Saving account: ${JSON.stringify(acc, null, 2)}`)
+                await store.save<Account>(acc)
+
+                const hab = new HistoricalAccountBalance()
+                hab.id = event.id + '-' + walletId.substring(walletId.length - 5)
+                hab.accountId = acc.accountId
+                hab.event = "PostHook"
+                hab.assetId = ab.assetId
+                hab.dBalance = BigInt(50000000000)
+                hab.balance = ab.balance
+                hab.dValue = Number(hab.dBalance)
+                hab.value = Number(hab.balance)
+                hab.pvalue = acc.pvalue
+                hab.blockNumber = block.height
+                hab.timestamp = new Date(block.timestamp)
+                console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`)
+                await store.save<HistoricalAccountBalance>(hab)
+            }
+            break
+        }
+    }
+}


### PR DESCRIPTION
PostHooks at block numbers before `#588249` for adding balances to account `dE4NbK6XC4dJEkjU5erpDNj2ydMh1fMNw8ug7xNgzTxqFo5iW` as stated at https://github.com/zeitgeistpm/zeitgeist/issues/444.