### PR TITLE
Process & map MarketClosedEvent

### DIFF
--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -3,7 +3,7 @@ import { balancesBalanceSet, balancesDustLost, balancesEndowed, balancesReserved
     balancesUnreserved, balancesWithdraw, currencyDeposited, currencyTransferred, currencyWithdrawn, 
     parachainStakingRewarded, systemExtrinsicFailed, systemExtrinsicSuccess, systemNewAccount, tokensEndowed } from "./balances";
 import { predictionMarketApproved, predictionMarketBoughtCompleteSet, predictionMarketCancelled, 
-    predictionMarketCreated, predictionMarketDisputed, predictionMarketInsufficientSubsidy, 
+    predictionMarketClosed, predictionMarketCreated, predictionMarketDisputed, predictionMarketInsufficientSubsidy, 
     predictionMarketRejected, predictionMarketReported, predictionMarketResolved, 
     predictionMarketSoldCompleteSet, predictionMarketStartedWithSubsidy, predictionMarketTokensRedeemed } from "./markets";
 import { add_balance_108949, add_balance_155917, add_balance_175178, add_balance_178290, add_balance_179524, 
@@ -46,6 +46,7 @@ processor.addEventHandler('predictionMarkets.MarketApproved', predictionMarketAp
 processor.addEventHandler('predictionMarkets.MarketCreated', predictionMarketCreated)
 processor.addEventHandler('predictionMarkets.MarketStartedWithSubsidy', predictionMarketStartedWithSubsidy)
 processor.addEventHandler('predictionMarkets.MarketInsufficientSubsidy', predictionMarketInsufficientSubsidy)
+processor.addEventHandler('predictionMarkets.MarketClosed', predictionMarketClosed)
 processor.addEventHandler('predictionMarkets.MarketDisputed', predictionMarketDisputed)
 processor.addEventHandler('predictionMarkets.MarketRejected', predictionMarketRejected)
 processor.addEventHandler('predictionMarkets.MarketReported', predictionMarketReported)

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -642,6 +642,37 @@ export class PredictionMarketsMarketCancelledEvent {
   }
 }
 
+export class PredictionMarketsMarketClosedEvent {
+  constructor(private ctx: EventContext) {
+    assert(this.ctx.event.name === 'predictionMarkets.MarketClosed')
+  }
+
+  /**
+   * A market has been closed \[market_id\]
+   */
+  get isV37(): boolean {
+    return this.ctx._chain.getEventHash('predictionMarkets.MarketClosed') === '985ece7379e4b9992d238f221ab40d6f104c871428514faea2d7ca35e2bfa0f5'
+  }
+
+  /**
+   * A market has been closed \[market_id\]
+   */
+  get asV37(): bigint {
+    assert(this.isV37)
+    return this.ctx._chain.decodeEvent(this.ctx.event)
+  }
+
+  get isLatest(): boolean {
+    deprecateLatest()
+    return this.isV37
+  }
+
+  get asLatest(): bigint {
+    deprecateLatest()
+    return this.asV37
+  }
+}
+
 export class PredictionMarketsMarketCreatedEvent {
   constructor(private ctx: EventContext) {
     assert(this.ctx.event.name === 'predictionMarkets.MarketCreated')

--- a/typegen.json
+++ b/typegen.json
@@ -22,6 +22,7 @@
       "predictionMarkets.MarketCreated",
       "predictionMarkets.MarketStartedWithSubsidy",
       "predictionMarkets.MarketInsufficientSubsidy",
+      "predictionMarkets.MarketClosed",
       "predictionMarkets.MarketDisputed",
       "predictionMarkets.MarketRejected",
       "predictionMarkets.MarketReported",


### PR DESCRIPTION
Process `Event::MarketClosed` (introduced on `v37`) emitted when the market ends. 
Trading is not allowed on markets that are closed.