### PR TITLE
Detach MarketCancelledEvent

### DIFF
--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -2,8 +2,8 @@ import { SubstrateProcessor } from "@subsquid/substrate-processor"
 import { balancesBalanceSet, balancesDustLost, balancesEndowed, balancesReserved, balancesTransfer, 
     balancesUnreserved, balancesWithdraw, currencyDeposited, currencyTransferred, currencyWithdrawn, 
     parachainStakingRewarded, systemExtrinsicFailed, systemExtrinsicSuccess, systemNewAccount, tokensEndowed } from "./balances";
-import { predictionMarketApproved, predictionMarketBoughtCompleteSet, predictionMarketCancelled, 
-    predictionMarketClosed, predictionMarketCreated, predictionMarketDisputed, predictionMarketInsufficientSubsidy, 
+import { predictionMarketApproved, predictionMarketBoughtCompleteSet, predictionMarketClosed, 
+    predictionMarketCreated, predictionMarketDisputed, predictionMarketInsufficientSubsidy, 
     predictionMarketRejected, predictionMarketReported, predictionMarketResolved, 
     predictionMarketSoldCompleteSet, predictionMarketStartedWithSubsidy, predictionMarketTokensRedeemed } from "./markets";
 import { add_balance_108949, add_balance_155917, add_balance_175178, add_balance_178290, add_balance_179524, 
@@ -50,7 +50,6 @@ processor.addEventHandler('predictionMarkets.MarketClosed', predictionMarketClos
 processor.addEventHandler('predictionMarkets.MarketDisputed', predictionMarketDisputed)
 processor.addEventHandler('predictionMarkets.MarketRejected', predictionMarketRejected)
 processor.addEventHandler('predictionMarkets.MarketReported', predictionMarketReported)
-processor.addEventHandler('predictionMarkets.MarketCancelled', predictionMarketCancelled)
 processor.addEventHandler('predictionMarkets.MarketResolved', predictionMarketResolved)
 processor.addEventHandler('predictionMarkets.SoldCompleteSet', predictionMarketSoldCompleteSet)
 processor.addEventHandler('predictionMarkets.TokensRedeemed', predictionMarketTokensRedeemed)

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -611,37 +611,6 @@ export class PredictionMarketsMarketApprovedEvent {
   }
 }
 
-export class PredictionMarketsMarketCancelledEvent {
-  constructor(private ctx: EventContext) {
-    assert(this.ctx.event.name === 'predictionMarkets.MarketCancelled')
-  }
-
-  /**
-   *  A pending market has been cancelled. \[market_id, creator\]
-   */
-  get isV23(): boolean {
-    return this.ctx._chain.getEventHash('predictionMarkets.MarketCancelled') === '47f20e4340181ef6a9fa426529a2a2f806c76198b2a3d7b22d1d1c9bc6b82e25'
-  }
-
-  /**
-   *  A pending market has been cancelled. \[market_id, creator\]
-   */
-  get asV23(): bigint {
-    assert(this.isV23)
-    return this.ctx._chain.decodeEvent(this.ctx.event)
-  }
-
-  get isLatest(): boolean {
-    deprecateLatest()
-    return this.isV23
-  }
-
-  get asLatest(): bigint {
-    deprecateLatest()
-    return this.asV23
-  }
-}
-
 export class PredictionMarketsMarketClosedEvent {
   constructor(private ctx: EventContext) {
     assert(this.ctx.event.name === 'predictionMarkets.MarketClosed')

--- a/typegen.json
+++ b/typegen.json
@@ -26,7 +26,6 @@
       "predictionMarkets.MarketDisputed",
       "predictionMarkets.MarketRejected",
       "predictionMarkets.MarketReported",
-      "predictionMarkets.MarketCancelled",
       "predictionMarkets.MarketResolved",
       "predictionMarkets.SoldCompleteSet",
       "predictionMarkets.TokensRedeemed",


### PR DESCRIPTION
This event hasn't been emitted yet on-chain. And post `v36` [release](https://github.com/zeitgeistpm/zeitgeist/releases/tag/v0.3.2), the chain has removed it completely.