### PR TITLE
Map baseAssetAmount & assetOut/assetIn from event params

### DIFF
--- a/src/processor/swaps.ts
+++ b/src/processor/swaps.ts
@@ -277,18 +277,24 @@ export async function swapExactAmountIn(ctx: EventHandlerContext) {
             const oldPrice = asset.price!
             var newAssetQty = oldAssetQty
 
-            if (extrinsic?.args[1] && wt!.assetId === JSON.stringify(extrinsic?.args[1].value)) {
-                newAssetQty = oldAssetQty + BigInt(swapEvent.assetAmountIn.toString())
-            } else if (extrinsic?.args[0].name === "calls") {
-                for (var ext of extrinsic.args[0].value as Array<{ args: { pool_id: number, asset_in: string, max_price: number }}> ) {
-                    const { args: { asset_in, pool_id } } = ext;
-                    if (pool_id == +swapEvent.cpep.poolId.toString() && wt!.assetId == JSON.stringify(asset_in)) {
-                        newAssetQty = oldAssetQty + BigInt(swapEvent.assetAmountIn.toString())
-                        break
-                    }
-                }
+            if (swapEvent.assetIn) {
+              if (wt!.assetId == JSON.stringify(swapEvent.assetIn)) {
+                  newAssetQty = oldAssetQty + BigInt(swapEvent.assetAmountIn.toString())
+              }
+            } else {
+              if (extrinsic?.args[1] && wt!.assetId === JSON.stringify(extrinsic?.args[1].value)) {
+                  newAssetQty = oldAssetQty + BigInt(swapEvent.assetAmountIn.toString())
+              } else if (extrinsic?.args[0].name === "calls") {
+                  for (var ext of extrinsic.args[0].value as Array<{ args: { pool_id: number, asset_in: string, max_price: number }}> ) {
+                      const { args: { asset_in, pool_id } } = ext;
+                      if (pool_id == +swapEvent.cpep.poolId.toString() && wt!.assetId == JSON.stringify(asset_in)) {
+                          newAssetQty = oldAssetQty + BigInt(swapEvent.assetAmountIn.toString())
+                          break
+                      }
+                  }
+              }
             }
-
+             
             const newPrice = await calcSpotPrice(+newZtgQty.toString(),ztgWt,+newAssetQty.toString(),assetWt,+savedPool.swapFee)
             asset.price = newPrice
             asset.amountInPool = newAssetQty

--- a/src/processor/swaps.ts
+++ b/src/processor/swaps.ts
@@ -355,16 +355,22 @@ export async function swapExactAmountOut(ctx: EventHandlerContext) {
             const oldPrice = asset.price!
             var newAssetQty = oldAssetQty
 
-            if (extrinsic?.args[1] && wt!.assetId === JSON.stringify(extrinsic?.args[3].value)) {
+            if (swapEvent.assetOut) {
+              if (wt!.assetId == JSON.stringify(swapEvent.assetOut)) {
                 newAssetQty = oldAssetQty - BigInt(swapEvent.assetAmountOut.toString())
-            } else if (extrinsic?.args[0].name === "calls") {
-                for (var ext of extrinsic.args[0].value as Array<{ args: { pool_id: number, asset_out: string, max_price: number }}> ) {
-                    const { args: { asset_out, pool_id } } = ext;
-                    if (pool_id == +swapEvent.cpep.poolId.toString() && wt!.assetId == JSON.stringify(asset_out)) {
-                        newAssetQty = oldAssetQty - BigInt(swapEvent.assetAmountOut.toString())
-                        break
-                    }
-                }
+              }
+            } else {
+              if (extrinsic?.args[1] && wt!.assetId === JSON.stringify(extrinsic?.args[3].value)) {
+                  newAssetQty = oldAssetQty - BigInt(swapEvent.assetAmountOut.toString())
+              } else if (extrinsic?.args[0].name === "calls") {
+                  for (var ext of extrinsic.args[0].value as Array<{ args: { pool_id: number, asset_out: string, max_price: number }}> ) {
+                      const { args: { asset_out, pool_id } } = ext;
+                      if (pool_id == +swapEvent.cpep.poolId.toString() && wt!.assetId == JSON.stringify(asset_out)) {
+                          newAssetQty = oldAssetQty - BigInt(swapEvent.assetAmountOut.toString())
+                          break
+                      }
+                  }
+              }
             }
 
             const newPrice = await calcSpotPrice(+newZtgQty.toString(),ztgWt,+newAssetQty.toString(),assetWt,+savedPool.swapFee)

--- a/src/processor/swaps.ts
+++ b/src/processor/swaps.ts
@@ -63,13 +63,13 @@ export async function swapPoolCreated(ctx: EventHandlerContext) {
             const asset = await store.get(Asset, { where: { assetId: entry[0] } })
             if (!asset) { return }
 
-            var ab = await store.get(AccountBalance, { where: { account: acc, assetId: asset.assetId } })
-            if (!ab) { return }
+            const ab = await store.get(AccountBalance, { where: { account: acc, assetId: asset.assetId } })
+            const tokenBalanceOut = ab ? +ab.balance.toString() : 1000000000000
 
-            const spotPrice = await calcSpotPrice(+newPool.ztgQty.toString(),weights.Ztg,+ab.balance.toString(),+weight.len.toString(), +pool.swapFee.toString())
+            const spotPrice = await calcSpotPrice(+newPool.ztgQty.toString(),weights.Ztg,tokenBalanceOut,+weight.len.toString(), +pool.swapFee.toString())
             asset.poolId = newPool.poolId
             asset.price = +spotPrice.toString()
-            asset.amountInPool = ab.balance
+            asset.amountInPool = BigInt(tokenBalanceOut)
             console.log(`[${event.name}] Saving asset: ${JSON.stringify(asset, null, 2)}`)
             await store.save<Asset>(asset)
 


### PR DESCRIPTION
These params were added on events after some time, however subsquid failed to pick them up which resulted in spot prices going crazy. This PR ensures they are stitched and secured.