### PR TITLE
Remap `market.scalarType`

### DIFF
--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -206,7 +206,7 @@ export async function marketCreated(ctx: EventHandlerContext<Store, {event: {arg
     newMarket.description = metadata.description
     newMarket.img = metadata.img
     
-    if ((market.marketType as any).scalar) {
+    if (market.marketType.__kind == 'Scalar') {
       newMarket.scalarType = metadata.scalarType;
     }
 


### PR DESCRIPTION
Based on firesquid changes, `scalarType` has been remapped.

Resolves https://github.com/zeitgeistpm/ui/pull/218#issuecomment-1298499909