### PR TITLE
Avoid multiple balance changes post mapping of TokensDepositedEvent

### DIFF
--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -29,69 +29,6 @@ export async function boughtCompleteSet(ctx: EventHandlerContext<Store>) {
   hm.timestamp = new Date(block.timestamp)
   console.log(`[${event.name}] Saving historical market: ${JSON.stringify(hm, null, 2)}`)
   await store.save<HistoricalMarket>(hm)
-
-  let acc = await store.get(Account, { where: { accountId: walletId } })
-  if (!acc) { return }
-
-  const len = market.outcomeAssets.length
-  for (let i = 0; i < len; i++) {
-    const currencyId = market.outcomeAssets[i]!
-    let ab = await store.findOneBy(AccountBalance, { account: { accountId: walletId }, assetId: currencyId })
-    if (!ab) { return }
-
-    let hab = await store.get(HistoricalAccountBalance, { where: 
-      { accountId: acc.accountId, assetId: currencyId, event: 'Endowed', blockNumber: block.height } })
-    if (hab) {
-      hab.event = hab.event.concat(event.name.split('.')[1])
-      console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`)
-      await store.save<HistoricalAccountBalance>(hab)
-    } else {
-      const asset = await store.get(Asset, { where: { assetId: currencyId } })
-      
-      let amt = BigInt(0)
-      if (amount !== BigInt(0)) {
-        amt = amount
-      } else if (event.extrinsic) {
-        if (event.extrinsic.call.args.amount) {
-          const amount = event.extrinsic.call.args.amount.toString()
-          amt = BigInt(amount)
-        } else if (event.extrinsic.call.args.calls) {
-          for (let ext of event.extrinsic.call.args.calls as 
-            Array<{ __kind: string, value: { __kind: string, amount: string, marketId: string} }> ) {
-            const { __kind: extrinsic, value: { __kind: method, amount: amount, marketId: id} } = ext;
-            if (extrinsic == 'PredictionMarkets' && method == 'buy_complete_set' && +id == marketId) {
-              amt = BigInt(amount)
-              break
-            }
-          }
-        }
-      }
-      ab.balance = ab.balance + amt
-      const oldValue = ab.value!
-      ab.value = asset ? asset.price ? asset.price * Number(ab.balance) : 0 : null
-      console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`)
-      await store.save<AccountBalance>(ab)
-
-      acc.pvalue = ab.value ? acc.pvalue! - oldValue + ab.value! : acc.pvalue
-      console.log(`[${event.name}] Saving account: ${JSON.stringify(acc, null, 2)}`)
-      await store.save<Account>(acc)
-
-      hab = new HistoricalAccountBalance()
-      hab.id = event.id + '-' + walletId.substring(walletId.length - 5)
-      hab.accountId = acc.accountId
-      hab.event = event.name.split('.')[1]
-      hab.assetId = ab.assetId
-      hab.dBalance = amt
-      hab.balance = ab.balance
-      hab.dValue = ab.value ? ab.value - oldValue : 0
-      hab.value = ab.value
-      hab.pvalue = acc.pvalue
-      hab.blockNumber = block.height
-      hab.timestamp = new Date(block.timestamp)
-      console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`)
-      await store.save<HistoricalAccountBalance>(hab)
-    }
-  }
 }
 
 export async function marketApproved(ctx: EventHandlerContext<Store, {event: {args: true}}>) {


### PR DESCRIPTION
Closes #254. `tokens.Deposited` events have been released along with the event `predictionMarkets.boughtCompleteSet` since the inception of `specVersion:36`. Hence accordingly, handler has been modified to pick this change.