### PR TITLE
Rescale bounds and resolved-outcome for old scalar markets

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -279,7 +279,7 @@ type MarketType @jsonField {
   "Number of categories if categorical market"
   categorical: String
   "Range of values if scalar market"
-  scalar: String
+  scalar: [String]
 }
 
 """

--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -132,7 +132,7 @@ export async function initBalance(acc: Account, store: Store, block: SubstrateBl
 }
 
 export function scaled(value: string): string {
-  return (+value * 10**10).toString();
+  return (BigInt(value) * BigInt(10**10)).toString();
 }
 
 interface DecodedMarketMetadata {

--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -131,6 +131,10 @@ export async function initBalance(acc: Account, store: Store, block: SubstrateBl
   await store.save<HistoricalAccountBalance>(hab)
 }
 
+export function scaled(value: string): string {
+  return (+value * 10**10).toString();
+}
+
 interface DecodedMarketMetadata {
   slug: string
   question: string

--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -131,7 +131,7 @@ export async function initBalance(acc: Account, store: Store, block: SubstrateBl
   await store.save<HistoricalAccountBalance>(hab)
 }
 
-export function scaled(value: string): string {
+export function rescale(value: string): string {
   return (BigInt(value) * BigInt(10**10)).toString();
 }
 

--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -506,7 +506,12 @@ export async function marketResolved(ctx: EventHandlerContext<Store, {event: {ar
   const market = await store.get(Market, { where: { marketId: marketId } })
   if (!market) return
 
-  market.resolvedOutcome = specVersion < 41 ? scaled(report.value.toString()) : report.value.toString();
+  if (market.marketType.scalar && specVersion < 41) {
+    market.resolvedOutcome = scaled(report.value.toString());
+  } else {
+    market.resolvedOutcome = report.value.toString();
+  }
+  
   const numOfOutcomeAssets = market.outcomeAssets.length;
   if (market.resolvedOutcome && numOfOutcomeAssets > 0) {
     for (let i = 0; i < numOfOutcomeAssets; i++) {

--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -6,7 +6,7 @@ import { Like } from 'typeorm'
 import { Account, AccountBalance, Asset, CategoryMetadata, HistoricalAccountBalance, HistoricalAsset, 
   HistoricalMarket, Market, MarketDeadlines, MarketPeriod, MarketReport, MarketType, OutcomeReport 
 } from '../../model'
-import { createAssetsForMarket, decodeMarketMetadata, scaled } from '../helper'
+import { createAssetsForMarket, decodeMarketMetadata, rescale } from '../helper'
 import { Tools } from '../util'
 import { getBoughtCompleteSetEvent, getMarketApprovedEvent, getMarketClosedEvent, getMarketCreatedEvent, 
   getMarketDestroyedEvent, getMarketDisputedEvent, getMarketExpiredEvent, getMarketInsufficientSubsidyEvent, 
@@ -251,12 +251,12 @@ export async function marketCreated(ctx: EventHandlerContext<Store, {event: {arg
     marketType.scalar = []
     if (specVersion < 41) {
       if (type.value.start) {
-        marketType.scalar.push(scaled(type.value.start.toString()));
-        marketType.scalar.push(scaled(type.value.end.toString()));
+        marketType.scalar.push(rescale(type.value.start.toString()));
+        marketType.scalar.push(rescale(type.value.end.toString()));
       } else {
         const [start, end] = type.value.toString().split(`,`);
-        marketType.scalar.push(scaled(start));
-        marketType.scalar.push(scaled(end));
+        marketType.scalar.push(rescale(start));
+        marketType.scalar.push(rescale(end));
       }
     } else {
       marketType.scalar.push(type.value.start.toString());
@@ -507,7 +507,7 @@ export async function marketResolved(ctx: EventHandlerContext<Store, {event: {ar
   if (!market) return
 
   if (market.marketType.scalar && specVersion < 41) {
-    market.resolvedOutcome = scaled(report.value.toString());
+    market.resolvedOutcome = rescale(report.value.toString());
   } else {
     market.resolvedOutcome = report.value.toString();
   }

--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -505,7 +505,11 @@ export async function marketResolved(ctx: EventHandlerContext<Store, {event: {ar
   const market = await store.get(Market, { where: { marketId: marketId } })
   if (!market) return
 
-  market.resolvedOutcome = report.value.toString()
+  if (specVersion < 41) {
+    market.resolvedOutcome = (+report.value.toString() * (10**10)).toString();
+  } else {
+    market.resolvedOutcome = report.value.toString();
+  }
 
   const numOfOutcomeAssets = market.outcomeAssets.length;
   if (market.resolvedOutcome && numOfOutcomeAssets > 0) {

--- a/src/model/generated/_marketType.ts
+++ b/src/model/generated/_marketType.ts
@@ -6,13 +6,13 @@ import * as marshal from "./marshal"
  */
 export class MarketType {
   private _categorical!: string | undefined | null
-  private _scalar!: string | undefined | null
+  private _scalar!: (string | undefined | null)[] | undefined | null
 
   constructor(props?: Partial<Omit<MarketType, 'toJSON'>>, json?: any) {
     Object.assign(this, props)
     if (json != null) {
       this._categorical = json.categorical == null ? undefined : marshal.string.fromJSON(json.categorical)
-      this._scalar = json.scalar == null ? undefined : marshal.string.fromJSON(json.scalar)
+      this._scalar = json.scalar == null ? undefined : marshal.fromList(json.scalar, val => val == null ? undefined : marshal.string.fromJSON(val))
     }
   }
 
@@ -30,11 +30,11 @@ export class MarketType {
   /**
    * Range of values if scalar market
    */
-  get scalar(): string | undefined | null {
+  get scalar(): (string | undefined | null)[] | undefined | null {
     return this._scalar
   }
 
-  set scalar(value: string | undefined | null) {
+  set scalar(value: (string | undefined | null)[] | undefined | null) {
     this._scalar = value
   }
 


### PR DESCRIPTION
Closes #261
Follows [changelog](https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/changelog_for_devs.md#v037):
```
Transformed integer scalar markets to fixed point with ten digits after the decimal point.
As soon as this update is deployed, the interpretation of the scalar values must be changed.
```