### PR TITLE
Optimize query for price history

### DIFF
--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -1,55 +1,33 @@
 import { encodedAssetId } from './helper';
 
-export const assetPriceHistory = (
-  assetId: string,
-  poolCreateTime: string,
-  startTime: string,
-  endTime: string,
-  interval: string
-) => `
-  SELECT
-    x.generate_series AS timestamp,
-    y.latest_value AS "${encodedAssetId(assetId)}"
-  FROM (
+export const assetPriceHistory = (assetId: string, startTime: string, endTime: string, interval: string) => `
+  WITH t0 AS (
     SELECT
       GENERATE_SERIES (
-        TIMEZONE('UTC', '${startTime}'::TIMESTAMP),
-        TIMEZONE('UTC', '${endTime}'::TIMESTAMP),
+        '${startTime}'::TIMESTAMP,
+        '${endTime}'::TIMESTAMP,
         '${interval}'::INTERVAL
-      )
-  ) x
-  LEFT JOIN (
+      ) AS timestamp_t0
+  )
+  SELECT
+    timestamp_t0 AS timestamp,
+    new_price AS "${encodedAssetId(assetId)}"
+  FROM
+    t0
+  LEFT JOIN LATERAL (
     SELECT
-      generate_series,
-      FIRST_VALUE(new_price) OVER (PARTITION BY value_partition ORDER BY generate_series) AS latest_value
-    FROM (
-      SELECT
-        *,
-        SUM(CASE WHEN new_price IS NULL THEN 0 ELSE 1 END) OVER (ORDER BY generate_series) AS value_partition
-      FROM (
-        SELECT
-          GENERATE_SERIES (
-            TIMEZONE('UTC', '${poolCreateTime}'::TIMESTAMP),
-            TIMEZONE('UTC', '${endTime}'::TIMESTAMP),
-            '1 SECOND'::INTERVAL
-          )
-      ) a
-      LEFT JOIN (
-        SELECT
-          DISTINCT ON (timestamp) DATE_TRUNC('SECOND', ha.timestamp::timestamp),
-          ha.new_price
-        FROM
-          historical_asset ha
-        WHERE
-          ha.asset_id LIKE '%${assetId}%'
-        ORDER BY
-          ha.timestamp,
-          ha.id DESC
-      ) b
-      ON b.date_trunc = a.generate_series
-    ) AS q
-  ) y
-  ON y.generate_series = x.generate_series;
+      timestamp,
+      new_price
+    FROM
+      historical_asset
+    WHERE
+      asset_id LIKE '%${assetId}%'
+      AND timestamp <= timestamp_t0
+    ORDER BY
+      timestamp DESC
+    LIMIT 1
+  ) a
+  ON 1 = 1;
 `;
 
 export const marketParticipants = (ids: string[]) => `

--- a/src/server-extension/resolvers/priceHistory.ts
+++ b/src/server-extension/resolvers/priceHistory.ts
@@ -45,23 +45,25 @@ export class PriceHistoryResolver {
     const market = await manager.query(marketInfo(marketId));
     if (!market[0]) return;
 
-    const poolCreateTime = market[0].timestamp.toISOString().replace('T', ' ').split('.')[0];
-    if (!startTime) startTime = poolCreateTime;
+    if (!startTime) {
+      let poolCreateTime = market[0].timestamp.toISOString();
+      startTime = poolCreateTime;
+    }
     if (!endTime && market[1]) {
       let marketResolvedTime = new Date(market[1].timestamp.toISOString());
       marketResolvedTime.setDate(marketResolvedTime.getDate() + 1);
-      endTime = marketResolvedTime.toISOString().replace('T', ' ').split('.')[0];
+      endTime = marketResolvedTime.toISOString();
     } else {
-      endTime = new Date().toISOString().replace('T', ' ').split('.')[0];
+      endTime = new Date().toISOString();
     }
 
     let merged = [];
     let priceHistory = await manager.query(
-      assetPriceHistory(market[0].outcome_assets[0], poolCreateTime, startTime, endTime, interval)
+      assetPriceHistory(market[0].outcome_assets[0], startTime, endTime, interval)
     );
     for (let i = 1; i < market[0].outcome_assets.length; i++) {
       let priceHistory2 = await manager.query(
-        assetPriceHistory(market[0].outcome_assets[i], poolCreateTime, startTime, endTime, interval)
+        assetPriceHistory(market[0].outcome_assets[i], startTime, endTime, interval)
       );
       merged = mergeByField(priceHistory, priceHistory2, 'timestamp');
       priceHistory = merged;


### PR DESCRIPTION
This removes the need to include each price change for a particular asset. The prices are picked directly from `HistoricalAsset` by comparing timestamps.