### PR TITLE
Order prices by id rather than timestamp

### DIFF
--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -24,7 +24,7 @@ export const assetPriceHistory = (assetId: string, startTime: string, endTime: s
       asset_id LIKE '%${assetId}%'
       AND timestamp <= timestamp_t0
     ORDER BY
-      timestamp DESC
+      id DESC
     LIMIT 1
   ) a
   ON 1 = 1;


### PR DESCRIPTION
 Closes #323. Changes the lookup field for ordering historical prices from `timestamp` to `id`

Price history failed to pick the correct value when there are multiple prices stored as a record for a single block number or timestamp (i.e., when multiple trades happen on the same block). In such a scenario, `id` would be the unique field on `HistoricalAsset` to consider timestamp as well as position in the block.