### PR TITLE
Fix redundant subscription alerts 

### DIFF
--- a/scripts/subscribe/proposedMarkets.ts
+++ b/scripts/subscribe/proposedMarkets.ts
@@ -22,7 +22,7 @@ client.subscribe(
   {
     query: `
       subscription {
-        markets(where: {status_eq: Proposed}) {
+        markets(where: {status_eq: Proposed}, limit: 1, orderBy: marketId_DESC) {
           description
           marketId
           marketType {
@@ -34,7 +34,7 @@ client.subscribe(
             start
           }
           question
-        }  
+        }
       }  
     `,
   },

--- a/scripts/subscribe/proposedMarkets.ts
+++ b/scripts/subscribe/proposedMarkets.ts
@@ -42,6 +42,7 @@ client.subscribe(
     next: ({ data }) => {
       const { markets } = data as any;
       if (markets.length > 0) {
+        console.log(markets[0]);
         postDiscordAlert(markets[0]);
       }
     },
@@ -55,7 +56,6 @@ client.subscribe(
 );
 
 const postDiscordAlert = async (market: Market) => {
-  console.log(market);
   await axios.post(WEBHOOK_URL, {
     username: 'Market Proposed Alert',
     content: '',


### PR DESCRIPTION
The query now captures the latest market which has been proposed instead of all markets which are still in proposed state.