### PR TITLE
Add `baseAssetTraded` on `HistoricalAsset`

### DIFF
--- a/db/migrations/1682400128837-Data.js
+++ b/db/migrations/1682400128837-Data.js
@@ -1,5 +1,5 @@
-module.exports = class Data1682002234889 {
-    name = 'Data1682002234889'
+module.exports = class Data1682400128837 {
+    name = 'Data1682400128837'
 
     async up(db) {
         await db.query(`CREATE TABLE "account" ("account_id" text NOT NULL, "id" character varying NOT NULL, "market_id" integer, "pool_id" integer, CONSTRAINT "PK_54115ee388cdb6d86bb4bf5b2ea" PRIMARY KEY ("id"))`)
@@ -12,7 +12,7 @@ module.exports = class Data1682002234889 {
         await db.query(`CREATE INDEX "IDX_7ae36e79b02d471a94b311dfbb" ON "pool" ("market_id") `)
         await db.query(`CREATE TABLE "asset" ("id" character varying NOT NULL, "asset_id" text NOT NULL, "price" numeric NOT NULL, "amount_in_pool" numeric NOT NULL, "pool_id" character varying, CONSTRAINT "PK_1209d107fe21482beaea51b745e" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_55d87b88a0e01b25819b9d4d5a" ON "asset" ("pool_id") `)
-        await db.query(`CREATE TABLE "historical_asset" ("id" character varying NOT NULL, "account_id" text, "ztg_traded" numeric, "asset_id" text NOT NULL, "d_price" numeric, "d_amount_in_pool" numeric, "new_price" numeric, "new_amount_in_pool" numeric, "event" text NOT NULL, "block_number" integer NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_24bfbff0fb73bae4960d7301293" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE TABLE "historical_asset" ("id" character varying NOT NULL, "account_id" text, "ztg_traded" numeric, "base_asset_traded" numeric, "asset_id" text NOT NULL, "d_price" numeric, "d_amount_in_pool" numeric, "new_price" numeric, "new_amount_in_pool" numeric, "event" text NOT NULL, "block_number" integer NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_24bfbff0fb73bae4960d7301293" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_a80a99f03b440bfec08b2926d6" ON "historical_asset" ("account_id") `)
         await db.query(`CREATE INDEX "IDX_d9ec182f218dc183716b8807cf" ON "historical_asset" ("asset_id") `)
         await db.query(`CREATE TABLE "market" ("authorized_address" text, "base_asset" text NOT NULL, "bonds" jsonb, "categories" jsonb, "creation" text NOT NULL, "creator" text NOT NULL, "creator_fee" integer, "deadlines" jsonb, "description" text, "disputes" jsonb, "dispute_mechanism" text NOT NULL, "id" character varying NOT NULL, "img" text, "market_id" integer NOT NULL, "market_type" jsonb NOT NULL, "metadata" text NOT NULL, "oracle" text NOT NULL, "outcome_assets" text array NOT NULL, "period" jsonb NOT NULL, "reject_reason" text, "report" jsonb, "resolved_outcome" text, "scalar_type" text, "scoring_rule" text NOT NULL, "slug" text, "status" character varying(19) NOT NULL, "tags" text array, "question" text, "pool_id" character varying, CONSTRAINT "PK_1e9a2963edfd331d92018e3abac" PRIMARY KEY ("id"))`)

--- a/db/migrations/1682401174187-Data.js
+++ b/db/migrations/1682401174187-Data.js
@@ -1,5 +1,5 @@
-module.exports = class Data1682400128837 {
-    name = 'Data1682400128837'
+module.exports = class Data1682401174187 {
+    name = 'Data1682401174187'
 
     async up(db) {
         await db.query(`CREATE TABLE "account" ("account_id" text NOT NULL, "id" character varying NOT NULL, "market_id" integer, "pool_id" integer, CONSTRAINT "PK_54115ee388cdb6d86bb4bf5b2ea" PRIMARY KEY ("id"))`)
@@ -7,7 +7,7 @@ module.exports = class Data1682400128837 {
         await db.query(`CREATE INDEX "IDX_029576f147e256f1f93e4865c7" ON "account_balance" ("account_id") `)
         await db.query(`CREATE TABLE "historical_account_balance" ("account_id" text NOT NULL, "asset_id" text NOT NULL, "block_number" integer NOT NULL, "d_balance" numeric NOT NULL, "event" text NOT NULL, "id" character varying NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_bfc701998dd9e45981c88f4d1af" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_082fc1e4bc8a039eab7ebc56ff" ON "historical_account_balance" ("account_id") `)
-        await db.query(`CREATE TABLE "pool" ("id" character varying NOT NULL, "pool_id" integer NOT NULL, "account_id" text, "base_asset" text NOT NULL, "market_id" integer NOT NULL, "pool_status" text NOT NULL, "scoring_rule" text NOT NULL, "swap_fee" text NOT NULL, "total_subsidy" text NOT NULL, "total_weight" text NOT NULL, "weights" jsonb NOT NULL, "ztg_qty" numeric NOT NULL, "base_asset_qty" numeric NOT NULL, "volume" numeric NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_db1bfe411e1516c01120b85f8fe" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE TABLE "pool" ("id" character varying NOT NULL, "pool_id" integer NOT NULL, "account_id" text NOT NULL, "base_asset" text NOT NULL, "market_id" integer NOT NULL, "pool_status" text NOT NULL, "scoring_rule" text NOT NULL, "swap_fee" text NOT NULL, "total_subsidy" text NOT NULL, "total_weight" text NOT NULL, "weights" jsonb NOT NULL, "ztg_qty" numeric NOT NULL, "base_asset_qty" numeric NOT NULL, "volume" numeric NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_db1bfe411e1516c01120b85f8fe" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_ac4a37826438cadcfca6b520be" ON "pool" ("pool_id") `)
         await db.query(`CREATE INDEX "IDX_7ae36e79b02d471a94b311dfbb" ON "pool" ("market_id") `)
         await db.query(`CREATE TABLE "asset" ("id" character varying NOT NULL, "asset_id" text NOT NULL, "price" numeric NOT NULL, "amount_in_pool" numeric NOT NULL, "pool_id" character varying, CONSTRAINT "PK_1209d107fe21482beaea51b745e" PRIMARY KEY ("id"))`)

--- a/schema.graphql
+++ b/schema.graphql
@@ -76,6 +76,8 @@ type HistoricalAsset @entity {
   accountId: String @index
   "Amount of ZTG which user spent/redeemed for swap trade"
   ztgTraded: BigInt
+  "Amount of base asset which user spent/redeemed for swap trade"
+  baseAssetTraded: BigInt
   "Zeitgeist's identifier for asset"
   assetId: String! @index
   "Price of the asset has decreased if -ve and +ve if increased"

--- a/schema.graphql
+++ b/schema.graphql
@@ -188,7 +188,7 @@ type Pool @entity {
   "Zeitgeist's identifier for pool"
   poolId: Int! @index
   "Zeitgeist's identifier for account"
-  accountId: String
+  accountId: String!
   "The base asset in the market swap pool (usually a currency)"
   baseAsset: String!
   marketId: Int! @index

--- a/src/mappings/swaps/index.ts
+++ b/src/mappings/swaps/index.ts
@@ -368,13 +368,8 @@ export const poolDestroyed = async (ctx: Ctx, block: SubstrateBlock, item: Event
   console.log(`[${item.event.name}] Saving historical pool: ${JSON.stringify(hp, null, 2)}`);
   await ctx.store.save<HistoricalPool>(hp);
 
-  let acc = await ctx.store.get(Account, {
-    where: { accountId: pool.accountId! },
-  });
-  if (!acc) return;
-
   let ab = await ctx.store.findOneBy(AccountBalance, {
-    account: { accountId: acc.accountId },
+    account: { accountId: pool.accountId },
     assetId: pool.baseAsset,
   });
   if (!ab) return;
@@ -385,8 +380,8 @@ export const poolDestroyed = async (ctx: Ctx, block: SubstrateBlock, item: Event
   await ctx.store.save<AccountBalance>(ab);
 
   let hab = new HistoricalAccountBalance();
-  hab.id = item.event.id + '-' + acc.accountId.substring(acc.accountId.length - 5);
-  hab.accountId = acc.accountId;
+  hab.id = item.event.id + '-' + pool.accountId.substring(pool.accountId.length - 5);
+  hab.accountId = pool.accountId;
   hab.event = item.event.name.split('.')[1];
   hab.assetId = ab.assetId;
   hab.dBalance = newBalance - oldBalance;

--- a/src/mappings/swaps/index.ts
+++ b/src/mappings/swaps/index.ts
@@ -895,15 +895,15 @@ export const swapExactAmountIn = async (ctx: Ctx, block: SubstrateBlock, item: E
   const assetBoughtQty = BigInt(swapEvent.assetAmountOut.toString());
   const assetSoldQty = BigInt(swapEvent.assetAmountIn.toString());
 
-  let ztgQty = pool.baseAssetQty;
+  let baseAssetQty = pool.baseAssetQty;
   let oldVolume = pool.volume;
   let newVolume = oldVolume;
   if (isBaseAsset(assetBought) || isBaseAsset(assetSold)) {
-    ztgQty = isBaseAsset(assetBought) ? ztgQty - assetBoughtQty : ztgQty + assetSoldQty;
+    baseAssetQty = isBaseAsset(assetBought) ? baseAssetQty - assetBoughtQty : baseAssetQty + assetSoldQty;
     newVolume = isBaseAsset(assetBought) ? oldVolume + assetBoughtQty : oldVolume + assetSoldQty;
 
-    pool.ztgQty = ztgQty;
-    pool.baseAssetQty = ztgQty;
+    pool.ztgQty = baseAssetQty;
+    pool.baseAssetQty = baseAssetQty;
     pool.volume = newVolume;
     console.log(`[${item.event.name}] Saving pool: ${JSON.stringify(pool, null, 2)}`);
     await ctx.store.save<Pool>(pool);
@@ -944,7 +944,7 @@ export const swapExactAmountIn = async (ctx: Ctx, block: SubstrateBlock, item: E
           newAssetQty = oldAssetQty + assetSoldQty;
         }
 
-        const newPrice = calcSpotPrice(+ztgQty.toString(), baseAssetWeight, +newAssetQty.toString(), assetWeight);
+        const newPrice = calcSpotPrice(+baseAssetQty.toString(), baseAssetWeight, +newAssetQty.toString(), assetWeight);
         asset.price = newPrice;
         asset.amountInPool = newAssetQty;
         console.log(`[${item.event.name}] Saving asset: ${JSON.stringify(asset, null, 2)}`);
@@ -955,6 +955,7 @@ export const swapExactAmountIn = async (ctx: Ctx, block: SubstrateBlock, item: E
         ha.accountId = newAssetQty == oldAssetQty ? null : walletId;
         ha.assetId = asset.assetId;
         ha.ztgTraded = newAssetQty == oldAssetQty ? BigInt(0) : newVolume - oldVolume;
+        ha.baseAssetTraded = newAssetQty == oldAssetQty ? BigInt(0) : newVolume - oldVolume;
         ha.newPrice = asset.price;
         ha.newAmountInPool = asset.amountInPool;
         ha.dPrice = newPrice - oldPrice;
@@ -1022,15 +1023,15 @@ export const swapExactAmountOut = async (ctx: Ctx, block: SubstrateBlock, item: 
   const assetBoughtQty = BigInt(swapEvent.assetAmountOut.toString());
   const assetSoldQty = BigInt(swapEvent.assetAmountIn.toString());
 
-  let ztgQty = pool.baseAssetQty;
+  let baseAssetQty = pool.baseAssetQty;
   let oldVolume = pool.volume;
   let newVolume = oldVolume;
   if (isBaseAsset(assetBought) || isBaseAsset(assetSold)) {
-    ztgQty = isBaseAsset(assetBought) ? ztgQty - assetBoughtQty : ztgQty + assetSoldQty;
+    baseAssetQty = isBaseAsset(assetBought) ? baseAssetQty - assetBoughtQty : baseAssetQty + assetSoldQty;
     newVolume = isBaseAsset(assetBought) ? oldVolume + assetBoughtQty : oldVolume + assetSoldQty;
 
-    pool.ztgQty = ztgQty;
-    pool.baseAssetQty = ztgQty;
+    pool.ztgQty = baseAssetQty;
+    pool.baseAssetQty = baseAssetQty;
     pool.volume = newVolume;
     console.log(`[${item.event.name}] Saving pool: ${JSON.stringify(pool, null, 2)}`);
     await ctx.store.save<Pool>(pool);
@@ -1071,7 +1072,7 @@ export const swapExactAmountOut = async (ctx: Ctx, block: SubstrateBlock, item: 
           newAssetQty = oldAssetQty + assetSoldQty;
         }
 
-        const newPrice = calcSpotPrice(+ztgQty.toString(), baseAssetWeight, +newAssetQty.toString(), assetWeight);
+        const newPrice = calcSpotPrice(+baseAssetQty.toString(), baseAssetWeight, +newAssetQty.toString(), assetWeight);
         asset.price = newPrice;
         asset.amountInPool = newAssetQty;
         console.log(`[${item.event.name}] Saving asset: ${JSON.stringify(asset, null, 2)}`);
@@ -1082,6 +1083,7 @@ export const swapExactAmountOut = async (ctx: Ctx, block: SubstrateBlock, item: 
         ha.accountId = newAssetQty == oldAssetQty ? null : walletId;
         ha.assetId = asset.assetId;
         ha.ztgTraded = newAssetQty == oldAssetQty ? BigInt(0) : newVolume - oldVolume;
+        ha.baseAssetTraded = newAssetQty == oldAssetQty ? BigInt(0) : newVolume - oldVolume;
         ha.newPrice = asset.price;
         ha.newAmountInPool = asset.amountInPool;
         ha.dPrice = newPrice - oldPrice;

--- a/src/mappings/swaps/index.ts
+++ b/src/mappings/swaps/index.ts
@@ -1,6 +1,5 @@
 import { SubstrateBlock } from '@subsquid/substrate-processor';
 import * as ss58 from '@subsquid/ss58';
-import { Like } from 'typeorm/find-options/operator/Like';
 import {
   Account,
   AccountBalance,

--- a/src/model/generated/historicalAsset.model.ts
+++ b/src/model/generated/historicalAsset.model.ts
@@ -31,6 +31,12 @@ export class HistoricalAsset {
     ztgTraded!: bigint | undefined | null
 
     /**
+     * Amount of base asset which user spent/redeemed for swap trade
+     */
+    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: true})
+    baseAssetTraded!: bigint | undefined | null
+
+    /**
      * Zeitgeist's identifier for asset
      */
     @Index_()

--- a/src/model/generated/pool.model.ts
+++ b/src/model/generated/pool.model.ts
@@ -25,8 +25,8 @@ export class Pool {
     /**
      * Zeitgeist's identifier for account
      */
-    @Column_("text", {nullable: true})
-    accountId!: string | undefined | null
+    @Column_("text", {nullable: false})
+    accountId!: string
 
     /**
      * The base asset in the market swap pool (usually a currency)


### PR DESCRIPTION
- Introduces new field `baseAssetTraded` as a replacement for `ztgTraded`
- Makes pool account's `accountId` non-nullable on pool schema