### PR TITLE
Handle rewarded events for specVersion < 33

### DIFF
--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -212,6 +212,10 @@ export const rescale = (value: string): string => {
   return (BigInt(value) * BigInt(10 ** 10)).toString();
 };
 
+export const specVersion = (specId: string): number => {
+  return +specId.substring(specId.indexOf('@') + 1);
+};
+
 interface DecodedMarketMetadata {
   slug: string;
   question: string;

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -380,15 +380,21 @@ processor.run(new TypeormDatabase(), async (ctx) => {
               const hab = await parachainStakingRewarded(ctx, block.header, item);
               const key = makeKey(hab.accountId, hab.assetId);
               balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
-            } else {
-              // Since specVersion:33, Balances.Deposit is always emitted with ParachainStaking.Rewarded
-              // To avoid redundant addition, DepositEvent is being utilised for recording rewards
-              const hab = balanceHistory.pop();
-              if (hab && hab.event === 'Deposit') {
-                hab.id = item.event.id + hab.id.slice(-6);
-                hab.event = item.event.name.split('.')[1];
-                balanceHistory.push(hab);
-              }
+              break;
+            }
+            if (!process.env.WS_NODE_URL?.includes(`bs`) && block.header.height < 174108) {
+              const hab = await parachainStakingRewarded(ctx, block.header, item);
+              const key = makeKey(hab.accountId, hab.assetId);
+              balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+              break;
+            }
+            // Since specVersion:33, Balances.Deposit is always emitted with ParachainStaking.Rewarded
+            // To avoid redundant addition, DepositEvent is being utilised for recording rewards
+            const hab = balanceHistory.pop();
+            if (hab && hab.event === 'Deposit') {
+              hab.id = item.event.id + hab.id.slice(-6);
+              hab.event = item.event.name.split('.')[1];
+              balanceHistory.push(hab);
             }
             break;
           }


### PR DESCRIPTION
- Addresses rewards received by `dE36Y98QpX8hEkLANntbtUvt7figSPGxSrDxU4sscuX989CTJ` on main node before `specVersion:33`
- Improves inclusion of `ParachainStaking.Rewarded`