### PR TITLE
Process & map PredictionMarketsRedeemSharesCall

### DIFF
--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -657,7 +657,7 @@ export const marketStartedWithSubsidy = async (ctx: Ctx, block: SubstrateBlock, 
 
 export const redeemShares = async (ctx: Ctx, block: SubstrateBlock, call: CallItem) => {
   // @ts-ignore
-  if (!call.origin || call.origin.value) return;
+  if (!call.origin || !call.origin.value) return;
   // @ts-ignore
   const walletId = encodeAddress(call.origin.value.value, 73);
 

--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -656,10 +656,12 @@ export const marketStartedWithSubsidy = async (ctx: Ctx, block: SubstrateBlock, 
 };
 
 export const redeemShares = async (ctx: Ctx, block: SubstrateBlock, call: CallItem) => {
-  const { marketId } = getRedeemSharesCall(ctx, call);
+  // @ts-ignore
+  if (!call.origin || call.origin.value) return;
   // @ts-ignore
   const walletId = encodeAddress(call.origin.value.value, 73);
 
+  const { marketId } = getRedeemSharesCall(ctx, call);
   let market = await ctx.store.get(Market, { where: { marketId: marketId } });
   if (!market) return;
 

--- a/src/mappings/predictionMarkets/types.ts
+++ b/src/mappings/predictionMarkets/types.ts
@@ -1,6 +1,7 @@
 import { encodeAddress } from '@polkadot/keyring';
 import * as ss58 from '@subsquid/ss58';
-import { Ctx, EventItem } from '../../processor';
+import { CallItem, Ctx, EventItem } from '../../processor';
+import { PredictionMarketsRedeemSharesCall } from '../../types/calls';
 import {
   PredictionMarketsBoughtCompleteSetEvent,
   PredictionMarketsMarketApprovedEvent,
@@ -237,6 +238,18 @@ export const getMarketStartedWithSubsidyEvent = (ctx: Ctx, item: EventItem): Mar
   }
 };
 
+export const getRedeemSharesCall = (ctx: Ctx, call: CallItem): RedeemSharesCall => {
+  const redeemSharesCall = new PredictionMarketsRedeemSharesCall(ctx, call);
+  if (redeemSharesCall.isV23) {
+    const marketId = Number(redeemSharesCall.asV23.marketId);
+    return { marketId };
+  } else {
+    // @ts-ignore
+    const marketId = Number(call.args.marketId);
+    return { marketId };
+  }
+};
+
 export const getSoldCompleteSetEvent = (ctx: Ctx, item: EventItem): SoldCompleteSetEvent => {
   const event = new PredictionMarketsSoldCompleteSetEvent(ctx, item.event);
   if (event.isV23) {
@@ -333,6 +346,10 @@ interface MarketResolvedEvent {
 interface MarketSubsidyEvent {
   marketId: number;
   status?: MarketStatus;
+}
+
+interface RedeemSharesCall {
+  marketId: number;
 }
 
 interface SoldCompleteSetEvent {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -363,9 +363,12 @@ processor.run(new TypeormDatabase(), async (ctx) => {
   for (let block of ctx.blocks) {
     for (let item of block.items) {
       // @ts-ignore
-      if (item.kind === 'call' && item.name === 'PredictionMarkets.redeem_shares') {
+      if (item.kind === 'call' && item.call.success) {
         // @ts-ignore
-        await redeemShares(ctx, block.header, item.call);
+        if (item.name === 'PredictionMarkets.redeem_shares') {
+          // @ts-ignore
+          await redeemShares(ctx, block.header, item.call);
+        }
       }
 
       if (item.kind === 'event') {

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -1,0 +1,50 @@
+import assert from 'assert'
+import {Chain, ChainContext, CallContext, Call, Result, Option} from './support'
+
+export class PredictionMarketsRedeemSharesCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'PredictionMarkets.redeem_shares')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     *  Redeems the winning shares of a prediction market.
+     * 
+     */
+    get isV23(): boolean {
+        return this._chain.getCallHash('PredictionMarkets.redeem_shares') === '2d8fec72d3e36c29cd347083d3311cbd62a17f1318b1377488dc738d486872af'
+    }
+
+    /**
+     *  Redeems the winning shares of a prediction market.
+     * 
+     */
+    get asV23(): {marketId: bigint} {
+        assert(this.isV23)
+        return this._chain.decodeCall(this.call)
+    }
+
+    /**
+     * Redeems the winning shares of a prediction market.
+     * 
+     */
+    get isV36(): boolean {
+        return this._chain.getCallHash('PredictionMarkets.redeem_shares') === 'b56842a00d00b24c300d8cd4359235b469945c309694d455d2ba2bd1de5d0d4e'
+    }
+
+    /**
+     * Redeems the winning shares of a prediction market.
+     * 
+     */
+    get asV36(): {marketId: bigint} {
+        assert(this.isV36)
+        return this._chain.decodeCall(this.call)
+    }
+}

--- a/typegen.json
+++ b/typegen.json
@@ -51,5 +51,5 @@
     "Tokens.Transfer",
     "Tokens.Withdrawn"
   ],
-  "calls": []
+  "calls": ["PredictionMarkets.redeem_shares"]
 }


### PR DESCRIPTION
Pull in `PredictionMarkets.redeem_shares` from archive as a substitute for `PredictionMarkets.TokensRedeemed` before `specVersion:35`. Closes #377.