### PR TITLE
Add non-null checks and replace pool-status

### DIFF
--- a/db/migrations/1686976504351-Data.js
+++ b/db/migrations/1686976504351-Data.js
@@ -1,5 +1,5 @@
-module.exports = class Data1686299393653 {
-    name = 'Data1686299393653'
+module.exports = class Data1686976504351 {
+    name = 'Data1686976504351'
 
     async up(db) {
         await db.query(`CREATE TABLE "account" ("account_id" text NOT NULL, "id" character varying NOT NULL, "market_id" integer, "pool_id" integer, CONSTRAINT "PK_54115ee388cdb6d86bb4bf5b2ea" PRIMARY KEY ("id"))`)
@@ -7,7 +7,7 @@ module.exports = class Data1686299393653 {
         await db.query(`CREATE INDEX "IDX_029576f147e256f1f93e4865c7" ON "account_balance" ("account_id") `)
         await db.query(`CREATE TABLE "historical_account_balance" ("account_id" text NOT NULL, "asset_id" text NOT NULL, "block_number" integer NOT NULL, "d_balance" numeric NOT NULL, "event" text NOT NULL, "id" character varying NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_bfc701998dd9e45981c88f4d1af" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_082fc1e4bc8a039eab7ebc56ff" ON "historical_account_balance" ("account_id") `)
-        await db.query(`CREATE TABLE "pool" ("id" character varying NOT NULL, "account_id" text NOT NULL, "base_asset" text NOT NULL, "base_asset_qty" numeric NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "market_id" integer NOT NULL, "pool_id" integer NOT NULL, "pool_status" text NOT NULL, "scoring_rule" text NOT NULL, "status" character varying(17) NOT NULL, "swap_fee" text NOT NULL, "total_subsidy" text NOT NULL, "total_weight" text NOT NULL, "volume" numeric NOT NULL, "weights" jsonb NOT NULL, CONSTRAINT "PK_db1bfe411e1516c01120b85f8fe" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE TABLE "pool" ("id" character varying NOT NULL, "account_id" text NOT NULL, "base_asset" text NOT NULL, "base_asset_qty" numeric NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "market_id" integer NOT NULL, "pool_id" integer NOT NULL, "scoring_rule" text NOT NULL, "status" character varying(17) NOT NULL, "swap_fee" text NOT NULL, "total_subsidy" text NOT NULL, "total_weight" text NOT NULL, "volume" numeric NOT NULL, "weights" jsonb NOT NULL, CONSTRAINT "PK_db1bfe411e1516c01120b85f8fe" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_7ae36e79b02d471a94b311dfbb" ON "pool" ("market_id") `)
         await db.query(`CREATE INDEX "IDX_ac4a37826438cadcfca6b520be" ON "pool" ("pool_id") `)
         await db.query(`CREATE TABLE "asset" ("id" character varying NOT NULL, "asset_id" text NOT NULL, "price" numeric NOT NULL, "amount_in_pool" numeric NOT NULL, "pool_id" character varying, CONSTRAINT "PK_1209d107fe21482beaea51b745e" PRIMARY KEY ("id"))`)
@@ -21,7 +21,7 @@ module.exports = class Data1686299393653 {
         await db.query(`CREATE INDEX "IDX_1a8068c93b7b3b7f483268ea11" ON "market" ("market_id") `)
         await db.query(`CREATE INDEX "IDX_190888a8e7a706187b12093c29" ON "market" ("pool_id") `)
         await db.query(`CREATE TABLE "historical_market" ("id" character varying NOT NULL, "block_number" integer NOT NULL, "by" text, "event" character varying(15) NOT NULL, "market_id" integer NOT NULL, "pool_id" integer, "outcome" jsonb, "resolved_outcome" text, "status" character varying(19) NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_8b5b3dfdac79a88102b94d55498" PRIMARY KEY ("id"))`)
-        await db.query(`CREATE TABLE "historical_pool" ("id" character varying NOT NULL, "base_asset_qty" numeric, "block_number" integer NOT NULL, "d_volume" numeric, "event" text NOT NULL, "pool_id" integer NOT NULL, "pool_status" text NOT NULL, "status" character varying(17) NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "volume" numeric, CONSTRAINT "PK_6ee31afe7b6dc3500a94effc951" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE TABLE "historical_pool" ("id" character varying NOT NULL, "base_asset_qty" numeric, "block_number" integer NOT NULL, "d_volume" numeric, "event" text NOT NULL, "pool_id" integer NOT NULL, "status" character varying(17) NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "volume" numeric, CONSTRAINT "PK_6ee31afe7b6dc3500a94effc951" PRIMARY KEY ("id"))`)
         await db.query(`ALTER TABLE "account_balance" ADD CONSTRAINT "FK_029576f147e256f1f93e4865c76" FOREIGN KEY ("account_id") REFERENCES "account"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)
         await db.query(`ALTER TABLE "asset" ADD CONSTRAINT "FK_55d87b88a0e01b25819b9d4d5aa" FOREIGN KEY ("pool_id") REFERENCES "pool"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)
         await db.query(`ALTER TABLE "market" ADD CONSTRAINT "FK_190888a8e7a706187b12093c29d" FOREIGN KEY ("pool_id") REFERENCES "pool"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)

--- a/schema.graphql
+++ b/schema.graphql
@@ -128,7 +128,7 @@ type Market @entity {
   "Tracks the status of the advisory, oracle and validity bonds"
   bonds: MarketBonds
   "Share details"
-  categories: [CategoryMetadata]
+  categories: [CategoryMetadata!]
   "Can be `Permissionless` or `Advised`"
   creation: MarketCreation!
   "Account address of the market creator"
@@ -241,7 +241,7 @@ type Pool @entity {
   "Total amount of ZTG that has moved through a market's liquidity pool"
   volume: BigInt!
   "List of lengths for each asset"
-  weights: [Weight]!
+  weights: [Weight!]!
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -226,8 +226,6 @@ type Pool @entity {
   marketId: Int! @index
   "Zeitgeist's identifier for pool"
   poolId: Int! @index
-  "Status of the pool"
-  poolStatus: String!
   "Scoring rule used for the pool"
   scoringRule: String!
   "Status of the pool"
@@ -259,8 +257,6 @@ type HistoricalPool @entity {
   event: String!
   "Zeitgeist's identifier for pool"
   poolId: Int!
-  "Current status of the pool"
-  poolStatus: String!
   "Current status of the pool"
   status: PoolStatus!
   "Timestamp of the block"

--- a/src/mappings/swaps/index.ts
+++ b/src/mappings/swaps/index.ts
@@ -42,7 +42,6 @@ export const arbitrageBuyBurn = async (ctx: Ctx, block: SubstrateBlock, item: Ev
     where: { poolId: +poolId.toString() },
   });
   if (!pool) return;
-
   const oldBaseAssetQty = pool.baseAssetQty;
   const newBaseAssetQty = oldBaseAssetQty + amount;
   pool.baseAssetQty = newBaseAssetQty;
@@ -54,7 +53,6 @@ export const arbitrageBuyBurn = async (ctx: Ctx, block: SubstrateBlock, item: Ev
   hp.poolId = pool.poolId;
   hp.event = item.event.name.split('.')[1];
   hp.baseAssetQty = pool.baseAssetQty;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.blockNumber = block.height;
   hp.timestamp = new Date(block.timestamp);
@@ -111,7 +109,6 @@ export const arbitrageMintSell = async (ctx: Ctx, block: SubstrateBlock, item: E
     where: { poolId: +poolId.toString() },
   });
   if (!pool) return;
-
   const oldBaseAssetQty = pool.baseAssetQty;
   const newBaseAssetQty = oldBaseAssetQty - amount;
   pool.baseAssetQty = newBaseAssetQty;
@@ -123,7 +120,6 @@ export const arbitrageMintSell = async (ctx: Ctx, block: SubstrateBlock, item: E
   hp.poolId = pool.poolId;
   hp.event = item.event.name.split('.')[1];
   hp.baseAssetQty = pool.baseAssetQty;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.blockNumber = block.height;
   hp.timestamp = new Date(block.timestamp);
@@ -180,15 +176,13 @@ export const poolActive = async (ctx: Ctx, block: SubstrateBlock, item: EventIte
     where: { poolId: +poolId.toString() },
   });
   if (!pool) return;
-
-  pool.poolStatus = PoolStatus.Active;
+  pool.status = PoolStatus.Active;
   console.log(`[${item.event.name}] Saving pool: ${JSON.stringify(pool, null, 2)}`);
   await ctx.store.save<Pool>(pool);
 
   const hp = new HistoricalPool();
   hp.id = item.event.id + '-' + pool.poolId;
   hp.poolId = pool.poolId;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.event = item.event.name.split('.')[1];
   hp.blockNumber = block.height;
@@ -204,15 +198,13 @@ export const poolClosed = async (ctx: Ctx, block: SubstrateBlock, item: EventIte
     where: { poolId: +poolId.toString() },
   });
   if (!pool) return;
-
-  pool.poolStatus = PoolStatus.Closed;
+  pool.status = PoolStatus.Closed;
   console.log(`[${item.event.name}] Saving pool: ${JSON.stringify(pool, null, 2)}`);
   await ctx.store.save<Pool>(pool);
 
   const hp = new HistoricalPool();
   hp.id = item.event.id + '-' + pool.poolId;
   hp.poolId = pool.poolId;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.event = item.event.name.split('.')[1];
   hp.blockNumber = block.height;
@@ -238,7 +230,6 @@ export const poolCreate = async (ctx: Ctx, block: SubstrateBlock, item: EventIte
   pool.poolId = +cpep.poolId.toString();
   pool.accountId = accountId;
   pool.marketId = +swapPool.marketId.toString();
-  pool.poolStatus = swapPool.poolStatus.__kind;
   pool.status = getPoolStatus(swapPool.poolStatus);
   pool.scoringRule = swapPool.scoringRule.__kind;
   pool.swapFee = swapPool.swapFee ? swapPool.swapFee.toString() : '';
@@ -319,7 +310,6 @@ export const poolCreate = async (ctx: Ctx, block: SubstrateBlock, item: EventIte
   hp.baseAssetQty = pool.baseAssetQty;
   hp.dVolume = pool.volume;
   hp.volume = pool.volume;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.blockNumber = block.height;
   hp.timestamp = new Date(block.timestamp);
@@ -353,7 +343,7 @@ export const poolDestroyed = async (ctx: Ctx, block: SubstrateBlock, item: Event
     where: { poolId: +poolId.toString() },
   });
   if (!pool) return;
-  pool.poolStatus = PoolStatus.Destroyed;
+  pool.status = PoolStatus.Destroyed;
   pool.baseAssetQty = BigInt(0);
   console.log(`[${item.event.name}] Saving pool: ${JSON.stringify(pool, null, 2)}`);
   await ctx.store.save<Pool>(pool);
@@ -363,7 +353,6 @@ export const poolDestroyed = async (ctx: Ctx, block: SubstrateBlock, item: Event
   hp.poolId = pool.poolId;
   hp.baseAssetQty = pool.baseAssetQty;
   hp.event = item.event.name.split('.')[1];
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.blockNumber = block.height;
   hp.timestamp = new Date(block.timestamp);
@@ -481,7 +470,6 @@ export const poolExit = async (ctx: Ctx, block: SubstrateBlock, item: EventItem)
   hp.poolId = pool.poolId;
   hp.event = item.event.name.split('.')[1];
   hp.baseAssetQty = pool.baseAssetQty;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.blockNumber = block.height;
   hp.timestamp = new Date(block.timestamp);
@@ -626,7 +614,6 @@ export const poolExitWithExactAssetAmount = async (ctx: Ctx, block: SubstrateBlo
     where: { poolId: +pae.cpep.poolId.toString() },
   });
   if (!pool || !isBaseAsset(pae.asset)) return;
-
   const oldBaseAssetQty = pool.baseAssetQty;
   const newBaseAssetQty = oldBaseAssetQty - BigInt(pae.transferred.toString());
   pool.baseAssetQty = newBaseAssetQty;
@@ -638,7 +625,6 @@ export const poolExitWithExactAssetAmount = async (ctx: Ctx, block: SubstrateBlo
   hp.poolId = pool.poolId;
   hp.event = item.event.name.split('.')[1];
   hp.baseAssetQty = pool.baseAssetQty;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.blockNumber = block.height;
   hp.timestamp = new Date(block.timestamp);
@@ -694,7 +680,6 @@ export const poolJoin = async (ctx: Ctx, block: SubstrateBlock, item: EventItem)
     where: { poolId: +pae.cpep.poolId.toString() },
   });
   if (!pool) return;
-
   const oldBaseAssetQty = pool.baseAssetQty;
   const newBaseAssetQty = oldBaseAssetQty + BigInt(pae.transferred[pae.transferred.length - 1].toString());
   pool.baseAssetQty = newBaseAssetQty;
@@ -706,7 +691,6 @@ export const poolJoin = async (ctx: Ctx, block: SubstrateBlock, item: EventItem)
   hp.poolId = pool.poolId;
   hp.event = item.event.name.split('.')[1];
   hp.baseAssetQty = pool.baseAssetQty;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.blockNumber = block.height;
   hp.timestamp = new Date(block.timestamp);
@@ -825,7 +809,6 @@ export const poolJoinWithExactAssetAmount = async (ctx: Ctx, block: SubstrateBlo
   hp.poolId = pool.poolId;
   hp.event = item.event.name.split('.')[1];
   hp.baseAssetQty = pool.baseAssetQty;
-  hp.poolStatus = pool.poolStatus;
   hp.status = pool.status;
   hp.blockNumber = block.height;
   hp.timestamp = new Date(block.timestamp);
@@ -946,7 +929,6 @@ export const swapExactAmountIn = async (ctx: Ctx, block: SubstrateBlock, item: E
     hp.baseAssetQty = pool.baseAssetQty;
     hp.dVolume = newVolume - oldVolume;
     hp.volume = newVolume;
-    hp.poolStatus = pool.poolStatus;
     hp.status = pool.status;
     hp.blockNumber = block.height;
     hp.timestamp = new Date(block.timestamp);
@@ -1085,7 +1067,6 @@ export const swapExactAmountOut = async (ctx: Ctx, block: SubstrateBlock, item: 
     hp.baseAssetQty = pool.baseAssetQty;
     hp.dVolume = newVolume - oldVolume;
     hp.volume = newVolume;
-    hp.poolStatus = pool.poolStatus;
     hp.status = pool.status;
     hp.blockNumber = block.height;
     hp.timestamp = new Date(block.timestamp);

--- a/src/model/generated/historicalPool.model.ts
+++ b/src/model/generated/historicalPool.model.ts
@@ -48,12 +48,6 @@ export class HistoricalPool {
     /**
      * Current status of the pool
      */
-    @Column_("text", {nullable: false})
-    poolStatus!: string
-
-    /**
-     * Current status of the pool
-     */
     @Column_("varchar", {length: 17, nullable: false})
     status!: PoolStatus
 

--- a/src/model/generated/market.model.ts
+++ b/src/model/generated/market.model.ts
@@ -40,8 +40,8 @@ export class Market {
     /**
      * Share details
      */
-    @Column_("jsonb", {transformer: {to: obj => obj == null ? undefined : obj.map((val: any) => val == null ? undefined : val.toJSON()), from: obj => obj == null ? undefined : marshal.fromList(obj, val => val == null ? undefined : new CategoryMetadata(undefined, val))}, nullable: true})
-    categories!: (CategoryMetadata | undefined | null)[] | undefined | null
+    @Column_("jsonb", {transformer: {to: obj => obj == null ? undefined : obj.map((val: any) => val.toJSON()), from: obj => obj == null ? undefined : marshal.fromList(obj, val => new CategoryMetadata(undefined, marshal.nonNull(val)))}, nullable: true})
+    categories!: (CategoryMetadata)[] | undefined | null
 
     /**
      * Can be `Permissionless` or `Advised`

--- a/src/model/generated/pool.model.ts
+++ b/src/model/generated/pool.model.ts
@@ -61,12 +61,6 @@ export class Pool {
     poolId!: number
 
     /**
-     * Status of the pool
-     */
-    @Column_("text", {nullable: false})
-    poolStatus!: string
-
-    /**
      * Scoring rule used for the pool
      */
     @Column_("text", {nullable: false})

--- a/src/model/generated/pool.model.ts
+++ b/src/model/generated/pool.model.ts
@@ -105,6 +105,6 @@ export class Pool {
     /**
      * List of lengths for each asset
      */
-    @Column_("jsonb", {transformer: {to: obj => obj.map((val: any) => val == null ? undefined : val.toJSON()), from: obj => obj == null ? undefined : marshal.fromList(obj, val => val == null ? undefined : new Weight(undefined, val))}, nullable: false})
-    weights!: (Weight | undefined | null)[]
+    @Column_("jsonb", {transformer: {to: obj => obj.map((val: any) => val.toJSON()), from: obj => obj == null ? undefined : marshal.fromList(obj, val => new Weight(undefined, marshal.nonNull(val)))}, nullable: false})
+    weights!: (Weight)[]
 }


### PR DESCRIPTION
- Pool `status` with stricter typing (Follows #356)
- Ensure non-null values inside `weights` and `categories` (Follows https://github.com/zeitgeistpm/sdk-next/issues/23)