### PR TITLE
Include outsider-bond and specVersion:46 changes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -286,7 +286,7 @@ type MarketBonds @jsonField {
   "Bond associated with oracle selection"
   oracle: MarketBond!
   "A bond for an outcome reporter, who is not the oracle"
-  outsider: MarketBond!
+  outsider: MarketBond
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -285,6 +285,8 @@ type MarketBonds @jsonField {
   creation: MarketBond!
   "Bond associated with oracle selection"
   oracle: MarketBond!
+  "A bond for an outcome reporter, who is not the oracle"
+  outsider: MarketBond!
 }
 
 """

--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -351,6 +351,14 @@ export const marketCreated = async (ctx: Ctx, block: SubstrateBlock, item: Event
       bond.isSettled = oracleBond.isSettled;
       marketBonds.oracle = bond;
     }
+    if (market.bonds.outsider) {
+      const outsiderBond = market.bonds.outsider;
+      const bond = new MarketBond();
+      bond.who = encodeAddress(outsiderBond.who, 73);
+      bond.value = outsiderBond.value;
+      bond.isSettled = outsiderBond.isSettled;
+      marketBonds.outsider = bond;
+    }
     newMarket.bonds = marketBonds;
   }
   console.log(`[${item.event.name}] Saving market: ${JSON.stringify(newMarket, null, 2)}`);

--- a/src/mappings/predictionMarkets/types.ts
+++ b/src/mappings/predictionMarkets/types.ts
@@ -95,16 +95,10 @@ export const getMarketCreatedEvent = (ctx: Ctx, item: EventItem, specVersion: nu
     market.period.start = market.period.value.start;
     market.period.end = market.period.value.end;
     return { marketId, marketAccountId, market };
-  } else if (event.isV38 || event.isV40 || event.isV41 || event.isV42) {
-    const marketAccountId = encodeAddress(param1, 73);
-    const market = param2 as any;
-    market.period.start = market.period.value.start;
-    market.period.end = market.period.value.end;
-    return { marketId, marketAccountId, market };
   } else {
     const marketAccountId = encodeAddress(param1, 73);
     const market = param2 as any;
-    market.period.start = param2.period.value.start;
+    market.period.start = market.period.value.start;
     market.period.end = market.period.value.end;
     return { marketId, marketAccountId, market };
   }

--- a/src/model/generated/_marketBonds.ts
+++ b/src/model/generated/_marketBonds.ts
@@ -10,12 +10,14 @@ import {MarketBond} from "./_marketBond"
 export class MarketBonds {
     private _creation!: MarketBond
     private _oracle!: MarketBond
+    private _outsider!: MarketBond
 
     constructor(props?: Partial<Omit<MarketBonds, 'toJSON'>>, json?: any) {
         Object.assign(this, props)
         if (json != null) {
             this._creation = new MarketBond(undefined, marshal.nonNull(json.creation))
             this._oracle = new MarketBond(undefined, marshal.nonNull(json.oracle))
+            this._outsider = new MarketBond(undefined, marshal.nonNull(json.outsider))
         }
     }
 
@@ -43,10 +45,23 @@ export class MarketBonds {
         this._oracle = value
     }
 
+    /**
+     * A bond for an outcome reporter, who is not the oracle
+     */
+    get outsider(): MarketBond {
+        assert(this._outsider != null, 'uninitialized access')
+        return this._outsider
+    }
+
+    set outsider(value: MarketBond) {
+        this._outsider = value
+    }
+
     toJSON(): object {
         return {
             creation: this.creation.toJSON(),
             oracle: this.oracle.toJSON(),
+            outsider: this.outsider.toJSON(),
         }
     }
 }

--- a/src/model/generated/_marketBonds.ts
+++ b/src/model/generated/_marketBonds.ts
@@ -10,14 +10,14 @@ import {MarketBond} from "./_marketBond"
 export class MarketBonds {
     private _creation!: MarketBond
     private _oracle!: MarketBond
-    private _outsider!: MarketBond
+    private _outsider!: MarketBond | undefined | null
 
     constructor(props?: Partial<Omit<MarketBonds, 'toJSON'>>, json?: any) {
         Object.assign(this, props)
         if (json != null) {
             this._creation = new MarketBond(undefined, marshal.nonNull(json.creation))
             this._oracle = new MarketBond(undefined, marshal.nonNull(json.oracle))
-            this._outsider = new MarketBond(undefined, marshal.nonNull(json.outsider))
+            this._outsider = json.outsider == null ? undefined : new MarketBond(undefined, json.outsider)
         }
     }
 
@@ -48,12 +48,11 @@ export class MarketBonds {
     /**
      * A bond for an outcome reporter, who is not the oracle
      */
-    get outsider(): MarketBond {
-        assert(this._outsider != null, 'uninitialized access')
+    get outsider(): MarketBond | undefined | null {
         return this._outsider
     }
 
-    set outsider(value: MarketBond) {
+    set outsider(value: MarketBond | undefined | null) {
         this._outsider = value
     }
 
@@ -61,7 +60,7 @@ export class MarketBonds {
         return {
             creation: this.creation.toJSON(),
             oracle: this.oracle.toJSON(),
-            outsider: this.outsider.toJSON(),
+            outsider: this.outsider == null ? undefined : this.outsider.toJSON(),
         }
     }
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -13,6 +13,7 @@ import * as v39 from './v39'
 import * as v40 from './v40'
 import * as v41 from './v41'
 import * as v42 from './v42'
+import * as v46 from './v46'
 
 export class BalancesBalanceSetEvent {
     private readonly _chain: Chain
@@ -840,6 +841,21 @@ export class PredictionMarketsMarketCreatedEvent {
      */
     get asV42(): [bigint, Uint8Array, v42.Market] {
         assert(this.isV42)
+        return this._chain.decodeEvent(this.event)
+    }
+
+    /**
+     * A market has been created. \[market_id, market_account, market\]
+     */
+    get isV46(): boolean {
+        return this._chain.getEventHash('PredictionMarkets.MarketCreated') === '8a1856bf3e540eda844210e0b265ed5193ffe9c3fecdc196fcb22a1f8c9f0d45'
+    }
+
+    /**
+     * A market has been created. \[market_id, market_account, market\]
+     */
+    get asV46(): [bigint, Uint8Array, v46.Market] {
+        assert(this.isV46)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -2187,6 +2203,21 @@ export class SystemExtrinsicFailedEvent {
         assert(this.isV42)
         return this._chain.decodeEvent(this.event)
     }
+
+    /**
+     * An extrinsic failed.
+     */
+    get isV46(): boolean {
+        return this._chain.getEventHash('System.ExtrinsicFailed') === '36c29895cd15b6f845bb064a671635ce07ef9de9648695c2803020e8510d0fb3'
+    }
+
+    /**
+     * An extrinsic failed.
+     */
+    get asV46(): {dispatchError: v46.DispatchError, dispatchInfo: v46.DispatchInfo} {
+        assert(this.isV46)
+        return this._chain.decodeEvent(this.event)
+    }
 }
 
 export class SystemExtrinsicSuccessEvent {
@@ -2244,6 +2275,21 @@ export class SystemExtrinsicSuccessEvent {
      */
     get asV42(): {dispatchInfo: v42.DispatchInfo} {
         assert(this.isV42)
+        return this._chain.decodeEvent(this.event)
+    }
+
+    /**
+     * An extrinsic completed successfully.
+     */
+    get isV46(): boolean {
+        return this._chain.getEventHash('System.ExtrinsicSuccess') === '6b78214e1591ecc2de1662ebf5ca93838612414a62415cde1cdd2962f8235a92'
+    }
+
+    /**
+     * An extrinsic completed successfully.
+     */
+    get asV46(): {dispatchInfo: v46.DispatchInfo} {
+        assert(this.isV46)
         return this._chain.decodeEvent(this.event)
     }
 }

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,0 +1,243 @@
+import assert from 'assert'
+import {Block, BlockContext, Chain, ChainContext, Option, Result, StorageBase} from './support'
+import * as v23 from './v23'
+import * as v32 from './v32'
+import * as v38 from './v38'
+import * as v40 from './v40'
+import * as v41 from './v41'
+import * as v42 from './v42'
+import * as v46 from './v46'
+
+export class MarketCommonsMarketsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'MarketCommons'
+    }
+
+    protected getName() {
+        return 'Markets'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get isV23(): boolean {
+        return this.getTypeHash() === '71ab4a5fd082e66e0f7bfe5377771881b06162ae81d40f6b9e5dfe45c2708ac3'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get asV23(): MarketCommonsMarketsStorageV23 {
+        assert(this.isV23)
+        return this as any
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get isV32(): boolean {
+        return this.getTypeHash() === '67bd271b1b95e6aae699f0ee769034cb86529cac2162b875db2a369aa8fe68cf'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get asV32(): MarketCommonsMarketsStorageV32 {
+        assert(this.isV32)
+        return this as any
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get isV38(): boolean {
+        return this.getTypeHash() === '55ada2a62fd3efc4fb1e1cfc8408a6c4724da02fb0c33607d093549879e68a5b'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get asV38(): MarketCommonsMarketsStorageV38 {
+        assert(this.isV38)
+        return this as any
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get isV40(): boolean {
+        return this.getTypeHash() === 'c975f07feb390b832e33b16164c7e83cc3f0e0767ee1ab31f7fe2fc7c64bf4ee'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get asV40(): MarketCommonsMarketsStorageV40 {
+        assert(this.isV40)
+        return this as any
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get isV41(): boolean {
+        return this.getTypeHash() === 'c40d832b2b21dedbe475029e4a36645ccbdb04426cbebc79e27252dbe5ab75df'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get asV41(): MarketCommonsMarketsStorageV41 {
+        assert(this.isV41)
+        return this as any
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get isV42(): boolean {
+        return this.getTypeHash() === '5dff1b5b718461ed75e820e1bd5ec31d59539e5b1f95a0f3a2dac7c1b4e2c6b6'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get asV42(): MarketCommonsMarketsStorageV42 {
+        assert(this.isV42)
+        return this as any
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get isV46(): boolean {
+        return this.getTypeHash() === 'f17f1b50ff6dde016a6732ed2bdaa0479f67c8bac03488cead37b6e8f9b3a8c6'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get asV46(): MarketCommonsMarketsStorageV46 {
+        assert(this.isV46)
+        return this as any
+    }
+}
+
+/**
+ *  Holds all markets
+ */
+export interface MarketCommonsMarketsStorageV23 {
+    get(key: bigint): Promise<(v23.Market | undefined)>
+    getAll(): Promise<v23.Market[]>
+    getMany(keys: bigint[]): Promise<(v23.Market | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v23.Market][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v23.Market][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v23.Market][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v23.Market][]>
+}
+
+/**
+ *  Holds all markets
+ */
+export interface MarketCommonsMarketsStorageV32 {
+    get(key: bigint): Promise<(v32.Market | undefined)>
+    getAll(): Promise<v32.Market[]>
+    getMany(keys: bigint[]): Promise<(v32.Market | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v32.Market][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v32.Market][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v32.Market][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v32.Market][]>
+}
+
+/**
+ *  Holds all markets
+ */
+export interface MarketCommonsMarketsStorageV38 {
+    get(key: bigint): Promise<(v38.Market | undefined)>
+    getAll(): Promise<v38.Market[]>
+    getMany(keys: bigint[]): Promise<(v38.Market | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v38.Market][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v38.Market][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v38.Market][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v38.Market][]>
+}
+
+/**
+ *  Holds all markets
+ */
+export interface MarketCommonsMarketsStorageV40 {
+    get(key: bigint): Promise<(v40.Market | undefined)>
+    getAll(): Promise<v40.Market[]>
+    getMany(keys: bigint[]): Promise<(v40.Market | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v40.Market][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v40.Market][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v40.Market][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v40.Market][]>
+}
+
+/**
+ *  Holds all markets
+ */
+export interface MarketCommonsMarketsStorageV41 {
+    get(key: bigint): Promise<(v41.Market | undefined)>
+    getAll(): Promise<v41.Market[]>
+    getMany(keys: bigint[]): Promise<(v41.Market | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v41.Market][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v41.Market][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v41.Market][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v41.Market][]>
+}
+
+/**
+ *  Holds all markets
+ */
+export interface MarketCommonsMarketsStorageV42 {
+    get(key: bigint): Promise<(v42.Market | undefined)>
+    getAll(): Promise<v42.Market[]>
+    getMany(keys: bigint[]): Promise<(v42.Market | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v42.Market][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v42.Market][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v42.Market][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v42.Market][]>
+}
+
+/**
+ *  Holds all markets
+ */
+export interface MarketCommonsMarketsStorageV46 {
+    get(key: bigint): Promise<(v46.Market | undefined)>
+    getAll(): Promise<v46.Market[]>
+    getMany(keys: bigint[]): Promise<(v46.Market | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v46.Market][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v46.Market][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v46.Market][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v46.Market][]>
+}

--- a/src/types/v46.ts
+++ b/src/types/v46.ts
@@ -1,0 +1,353 @@
+import type {Result, Option} from './support'
+
+export interface Market {
+    baseAsset: Asset
+    creator: Uint8Array
+    creation: MarketCreation
+    creatorFee: number
+    oracle: Uint8Array
+    metadata: Uint8Array
+    marketType: MarketType
+    period: MarketPeriod
+    deadlines: Deadlines
+    scoringRule: ScoringRule
+    status: MarketStatus
+    report: (Report | undefined)
+    resolvedOutcome: (OutcomeReport | undefined)
+    disputeMechanism: MarketDisputeMechanism
+    bonds: MarketBonds
+}
+
+export type DispatchError = DispatchError_Other | DispatchError_CannotLookup | DispatchError_BadOrigin | DispatchError_Module | DispatchError_ConsumerRemaining | DispatchError_NoProviders | DispatchError_TooManyConsumers | DispatchError_Token | DispatchError_Arithmetic | DispatchError_Transactional | DispatchError_Exhausted | DispatchError_Corruption | DispatchError_Unavailable
+
+export interface DispatchError_Other {
+    __kind: 'Other'
+}
+
+export interface DispatchError_CannotLookup {
+    __kind: 'CannotLookup'
+}
+
+export interface DispatchError_BadOrigin {
+    __kind: 'BadOrigin'
+}
+
+export interface DispatchError_Module {
+    __kind: 'Module'
+    value: ModuleError
+}
+
+export interface DispatchError_ConsumerRemaining {
+    __kind: 'ConsumerRemaining'
+}
+
+export interface DispatchError_NoProviders {
+    __kind: 'NoProviders'
+}
+
+export interface DispatchError_TooManyConsumers {
+    __kind: 'TooManyConsumers'
+}
+
+export interface DispatchError_Token {
+    __kind: 'Token'
+    value: TokenError
+}
+
+export interface DispatchError_Arithmetic {
+    __kind: 'Arithmetic'
+    value: ArithmeticError
+}
+
+export interface DispatchError_Transactional {
+    __kind: 'Transactional'
+    value: TransactionalError
+}
+
+export interface DispatchError_Exhausted {
+    __kind: 'Exhausted'
+}
+
+export interface DispatchError_Corruption {
+    __kind: 'Corruption'
+}
+
+export interface DispatchError_Unavailable {
+    __kind: 'Unavailable'
+}
+
+export interface DispatchInfo {
+    weight: Weight
+    class: DispatchClass
+    paysFee: Pays
+}
+
+export type Asset = Asset_CategoricalOutcome | Asset_ScalarOutcome | Asset_CombinatorialOutcome | Asset_PoolShare | Asset_Ztg | Asset_ForeignAsset
+
+export interface Asset_CategoricalOutcome {
+    __kind: 'CategoricalOutcome'
+    value: [bigint, number]
+}
+
+export interface Asset_ScalarOutcome {
+    __kind: 'ScalarOutcome'
+    value: [bigint, ScalarPosition]
+}
+
+export interface Asset_CombinatorialOutcome {
+    __kind: 'CombinatorialOutcome'
+}
+
+export interface Asset_PoolShare {
+    __kind: 'PoolShare'
+    value: bigint
+}
+
+export interface Asset_Ztg {
+    __kind: 'Ztg'
+}
+
+export interface Asset_ForeignAsset {
+    __kind: 'ForeignAsset'
+    value: number
+}
+
+export type MarketCreation = MarketCreation_Permissionless | MarketCreation_Advised
+
+export interface MarketCreation_Permissionless {
+    __kind: 'Permissionless'
+}
+
+export interface MarketCreation_Advised {
+    __kind: 'Advised'
+}
+
+export type MarketType = MarketType_Categorical | MarketType_Scalar
+
+export interface MarketType_Categorical {
+    __kind: 'Categorical'
+    value: number
+}
+
+export interface MarketType_Scalar {
+    __kind: 'Scalar'
+    value: RangeInclusive
+}
+
+export type MarketPeriod = MarketPeriod_Block | MarketPeriod_Timestamp
+
+export interface MarketPeriod_Block {
+    __kind: 'Block'
+    value: Range
+}
+
+export interface MarketPeriod_Timestamp {
+    __kind: 'Timestamp'
+    value: Range
+}
+
+export interface Deadlines {
+    gracePeriod: bigint
+    oracleDuration: bigint
+    disputeDuration: bigint
+}
+
+export type ScoringRule = ScoringRule_CPMM | ScoringRule_RikiddoSigmoidFeeMarketEma
+
+export interface ScoringRule_CPMM {
+    __kind: 'CPMM'
+}
+
+export interface ScoringRule_RikiddoSigmoidFeeMarketEma {
+    __kind: 'RikiddoSigmoidFeeMarketEma'
+}
+
+export type MarketStatus = MarketStatus_Proposed | MarketStatus_Active | MarketStatus_Suspended | MarketStatus_Closed | MarketStatus_CollectingSubsidy | MarketStatus_InsufficientSubsidy | MarketStatus_Reported | MarketStatus_Disputed | MarketStatus_Resolved
+
+export interface MarketStatus_Proposed {
+    __kind: 'Proposed'
+}
+
+export interface MarketStatus_Active {
+    __kind: 'Active'
+}
+
+export interface MarketStatus_Suspended {
+    __kind: 'Suspended'
+}
+
+export interface MarketStatus_Closed {
+    __kind: 'Closed'
+}
+
+export interface MarketStatus_CollectingSubsidy {
+    __kind: 'CollectingSubsidy'
+}
+
+export interface MarketStatus_InsufficientSubsidy {
+    __kind: 'InsufficientSubsidy'
+}
+
+export interface MarketStatus_Reported {
+    __kind: 'Reported'
+}
+
+export interface MarketStatus_Disputed {
+    __kind: 'Disputed'
+}
+
+export interface MarketStatus_Resolved {
+    __kind: 'Resolved'
+}
+
+export interface Report {
+    at: bigint
+    by: Uint8Array
+    outcome: OutcomeReport
+}
+
+export type OutcomeReport = OutcomeReport_Categorical | OutcomeReport_Scalar
+
+export interface OutcomeReport_Categorical {
+    __kind: 'Categorical'
+    value: number
+}
+
+export interface OutcomeReport_Scalar {
+    __kind: 'Scalar'
+    value: bigint
+}
+
+export type MarketDisputeMechanism = MarketDisputeMechanism_Authorized | MarketDisputeMechanism_Court | MarketDisputeMechanism_SimpleDisputes
+
+export interface MarketDisputeMechanism_Authorized {
+    __kind: 'Authorized'
+}
+
+export interface MarketDisputeMechanism_Court {
+    __kind: 'Court'
+}
+
+export interface MarketDisputeMechanism_SimpleDisputes {
+    __kind: 'SimpleDisputes'
+}
+
+export interface MarketBonds {
+    creation: (Bond | undefined)
+    oracle: (Bond | undefined)
+    outsider: (Bond | undefined)
+}
+
+export interface ModuleError {
+    index: number
+    error: Uint8Array
+}
+
+export type TokenError = TokenError_NoFunds | TokenError_WouldDie | TokenError_BelowMinimum | TokenError_CannotCreate | TokenError_UnknownAsset | TokenError_Frozen | TokenError_Unsupported
+
+export interface TokenError_NoFunds {
+    __kind: 'NoFunds'
+}
+
+export interface TokenError_WouldDie {
+    __kind: 'WouldDie'
+}
+
+export interface TokenError_BelowMinimum {
+    __kind: 'BelowMinimum'
+}
+
+export interface TokenError_CannotCreate {
+    __kind: 'CannotCreate'
+}
+
+export interface TokenError_UnknownAsset {
+    __kind: 'UnknownAsset'
+}
+
+export interface TokenError_Frozen {
+    __kind: 'Frozen'
+}
+
+export interface TokenError_Unsupported {
+    __kind: 'Unsupported'
+}
+
+export type ArithmeticError = ArithmeticError_Underflow | ArithmeticError_Overflow | ArithmeticError_DivisionByZero
+
+export interface ArithmeticError_Underflow {
+    __kind: 'Underflow'
+}
+
+export interface ArithmeticError_Overflow {
+    __kind: 'Overflow'
+}
+
+export interface ArithmeticError_DivisionByZero {
+    __kind: 'DivisionByZero'
+}
+
+export type TransactionalError = TransactionalError_LimitReached | TransactionalError_NoLayer
+
+export interface TransactionalError_LimitReached {
+    __kind: 'LimitReached'
+}
+
+export interface TransactionalError_NoLayer {
+    __kind: 'NoLayer'
+}
+
+export interface Weight {
+    refTime: bigint
+    proofSize: bigint
+}
+
+export type DispatchClass = DispatchClass_Normal | DispatchClass_Operational | DispatchClass_Mandatory
+
+export interface DispatchClass_Normal {
+    __kind: 'Normal'
+}
+
+export interface DispatchClass_Operational {
+    __kind: 'Operational'
+}
+
+export interface DispatchClass_Mandatory {
+    __kind: 'Mandatory'
+}
+
+export type Pays = Pays_Yes | Pays_No
+
+export interface Pays_Yes {
+    __kind: 'Yes'
+}
+
+export interface Pays_No {
+    __kind: 'No'
+}
+
+export type ScalarPosition = ScalarPosition_Long | ScalarPosition_Short
+
+export interface ScalarPosition_Long {
+    __kind: 'Long'
+}
+
+export interface ScalarPosition_Short {
+    __kind: 'Short'
+}
+
+export interface RangeInclusive {
+    start: bigint
+    end: bigint
+}
+
+export interface Range {
+    start: bigint
+    end: bigint
+}
+
+export interface Bond {
+    who: Uint8Array
+    value: bigint
+    isSettled: boolean
+}

--- a/typegen.json
+++ b/typegen.json
@@ -50,5 +50,6 @@
     "Tokens.Transfer",
     "Tokens.Withdrawn"
   ],
-  "calls": ["PredictionMarkets.redeem_shares", "Swaps.pool_exit"]
+  "calls": ["PredictionMarkets.redeem_shares", "Swaps.pool_exit"],
+  "storage": ["MarketCommons.Markets"]
 }


### PR DESCRIPTION
- Adapt to on-chain market struct changes
- Fetch market via storage call `MarketCommons.Markets` when reported (if required)
- Settle outsider-bond during market resolution and destruction (if applicable)