### PR TITLE
Accept asset kind and value for fetching balanceInfo

### DIFF
--- a/src/server-extension/resolvers/balanceInfo.ts
+++ b/src/server-extension/resolvers/balanceInfo.ts
@@ -16,6 +16,36 @@ export class BalanceInfo {
   }
 }
 
+enum AssetKind {
+  CategoricalOutcome = 'CategoricalOutcome',
+  ForeignAsset = 'ForeignAsset',
+  PoolShare = 'PoolShare',
+  ScalarOutcome = 'ScalarOutcome',
+  Ztg = 'Ztg',
+}
+
+registerEnumType(AssetKind, {
+  name: 'AssetKind',
+  description: 'Kind of asset',
+});
+
+@InputType()
+class AssetKindValue {
+  @Field(() => AssetKind)
+  kind!: AssetKind;
+
+  @Field(() => Int, { nullable: true })
+  value!: number;
+
+  constructor(props: Partial<AssetKindValue>) {
+    Object.assign(this, props);
+  }
+
+  toString(): string {
+    return getAssetId({ __kind: this.kind, value: this.value });
+  }
+}
+
 @Resolver()
 export class BalanceInfoResolver {
   constructor(private tx: () => Promise<EntityManager>) {}

--- a/src/server-extension/resolvers/balanceInfo.ts
+++ b/src/server-extension/resolvers/balanceInfo.ts
@@ -1,7 +1,8 @@
-import { Arg, Field, ObjectType, Query, Resolver } from 'type-graphql';
+import { Arg, Field, Int, ObjectType, Query, Resolver, registerEnumType, InputType } from 'type-graphql';
 import type { EntityManager } from 'typeorm';
 import { HistoricalAccountBalance } from '../../model/generated';
 import { balanceInfo } from '../query';
+import { getAssetId } from '../../mappings/helper';
 
 @ObjectType()
 export class BalanceInfo {
@@ -53,13 +54,13 @@ export class BalanceInfoResolver {
   @Query(() => BalanceInfo, { nullable: true })
   async balanceInfo(
     @Arg('accountId', () => String, { nullable: false }) accountId: string,
-    @Arg('assetId', () => String, { nullable: true }) assetId: string,
+    @Arg('assetId', () => AssetKindValue) assetId: AssetKindValue,
     @Arg('blockNumber', () => String, { nullable: false }) blockNumber: string
   ): Promise<BalanceInfo> {
     const manager = await this.tx();
     const result = await manager
       .getRepository(HistoricalAccountBalance)
-      .query(balanceInfo(accountId, assetId ?? 'Ztg', blockNumber));
+      .query(balanceInfo(accountId, assetId.toString(), blockNumber));
 
     return result[0];
   }


### PR DESCRIPTION
Downstreams would make use of strongly typed `assetId` as query variables on `balanceInfo`.