### PR TITLE
Allow querying cached metadata on redis

### DIFF
--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -48,7 +48,7 @@ export const createAssetsForMarket = async (marketId: string, marketType: any): 
 
 export const decodeMarketMetadata = async (metadata: string): Promise<DecodedMarketMetadata | undefined> => {
   if (metadata.startsWith('0x1530fa0bb52e67d0d9f89bf26552e1')) return undefined;
-  let raw = await (await Cache.init()).getMeta(metadata);
+  let raw = await (await Cache.init()).getDecodedMetadata(metadata);
   if (raw && !(process.env.NODE_ENV == 'local')) {
     return raw !== '0' ? (JSON.parse(raw) as DecodedMarketMetadata) : undefined;
   } else {
@@ -56,12 +56,12 @@ export const decodeMarketMetadata = async (metadata: string): Promise<DecodedMar
       const ipfs = new IPFS();
       raw = await ipfs.read(metadata);
       const rawData = JSON.parse(raw) as DecodedMarketMetadata;
-      await (await Cache.init()).setMeta(metadata, raw);
+      await (await Cache.init()).setDecodedMetadata(metadata, raw);
       return rawData;
     } catch (err) {
       console.error(err);
       if (err instanceof SyntaxError) {
-        await (await Cache.init()).setMeta(metadata, '0');
+        await (await Cache.init()).setDecodedMetadata(metadata, '0');
       }
       return undefined;
     }

--- a/src/mappings/util.ts
+++ b/src/mappings/util.ts
@@ -34,15 +34,12 @@ export class Cache {
     return `${prefix}_${key}`;
   }
 
-  async setMeta(key: string, value: string): Promise<void> {
+  async setDecodedMetadata(key: string, value: string): Promise<void> {
     return new Promise((resolve, reject) => {
       const cacheKey = this.makeKey('meta', key);
       this.client.set(cacheKey, value, (err: any) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
+        if (err) reject(err);
+        else resolve();
       });
     });
   }
@@ -60,15 +57,12 @@ export class Cache {
     });
   }
 
-  async getMeta(key: string): Promise<string | null> {
+  async getDecodedMetadata(key: string): Promise<string | null> {
     return new Promise((resolve, reject) => {
       const cacheKey = this.makeKey('meta', key);
       this.client.get(cacheKey, (err: any, data: string | PromiseLike<string | null> | null) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(data);
-        }
+        if (err) reject(err);
+        else resolve(data);
       });
     });
   }

--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -92,6 +92,16 @@ export const marketInfo = (marketId: number) => `
     hm.timestamp;
 `;
 
+export const marketMetadata = (ids: number[]) => `
+  SELECT
+    m.market_id,
+    m.metadata
+  FROM
+    market m
+  WHERE
+    m.market_id IN (${ids});
+`;
+
 export const totalLiquidityAndVolume = () => `
   SELECT
     ROUND(SUM(liquidity),0) AS total_liquidity,

--- a/src/server-extension/resolvers/index.ts
+++ b/src/server-extension/resolvers/index.ts
@@ -1,6 +1,7 @@
 import { BalanceInfoResolver } from './balanceInfo';
+import { MarketMetadataResolver } from './marketMetadata';
 import { MarketStatsResolver } from './marketStats';
 import { PriceHistoryResolver } from './priceHistory';
 import { StatsResolver } from './stats';
 
-export { BalanceInfoResolver, MarketStatsResolver, PriceHistoryResolver, StatsResolver };
+export { BalanceInfoResolver, MarketMetadataResolver, MarketStatsResolver, PriceHistoryResolver, StatsResolver };

--- a/src/server-extension/resolvers/marketMetadata.ts
+++ b/src/server-extension/resolvers/marketMetadata.ts
@@ -31,10 +31,11 @@ export class MarketMetadataResolver {
 
     let result: MarketMetadata[] = await Promise.all(
       encodedData.map(async (ed: any) => {
+        const decodedData = await (await Cache.init()).getMeta(ed.metadata);
         return {
           marketId: ed.market_id,
           encoded: ed.metadata,
-          decoded: await (await Cache.init()).getMeta(ed.metadata),
+          decoded: decodedData !== '0' ? decodedData : null, // '0' implies non-decodable metadata
         };
       })
     );

--- a/src/server-extension/resolvers/marketMetadata.ts
+++ b/src/server-extension/resolvers/marketMetadata.ts
@@ -1,0 +1,43 @@
+import { Arg, Field, Int, ObjectType, Query, Resolver } from 'type-graphql';
+import type { EntityManager } from 'typeorm';
+import { Market } from '../../model/generated';
+import { Cache } from '../../mappings/util';
+import { marketMetadata } from '../query';
+
+@ObjectType()
+export class MarketMetadata {
+  @Field(() => Int)
+  marketId!: number;
+
+  @Field(() => String)
+  encoded!: string;
+
+  @Field(() => String, { nullable: true })
+  decoded!: string;
+
+  constructor(props: Partial<MarketMetadata>) {
+    Object.assign(this, props);
+  }
+}
+
+@Resolver()
+export class MarketMetadataResolver {
+  constructor(private tx: () => Promise<EntityManager>) {}
+
+  @Query(() => [MarketMetadata])
+  async marketMetadata(@Arg('marketId', () => [Int!], { nullable: false }) ids: number[]): Promise<MarketMetadata[]> {
+    const manager = await this.tx();
+    const encodedData = await manager.getRepository(Market).query(marketMetadata(ids));
+
+    let result: MarketMetadata[] = await Promise.all(
+      encodedData.map(async (ed: any) => {
+        return {
+          marketId: ed.market_id,
+          encoded: ed.metadata,
+          decoded: await (await Cache.init()).getMeta(ed.metadata),
+        };
+      })
+    );
+    return result;
+  }
+}

--- a/src/server-extension/resolvers/marketMetadata.ts
+++ b/src/server-extension/resolvers/marketMetadata.ts
@@ -31,7 +31,7 @@ export class MarketMetadataResolver {
 
     let result: MarketMetadata[] = await Promise.all(
       encodedData.map(async (ed: any) => {
-        const decodedData = await (await Cache.init()).getMeta(ed.metadata);
+        const decodedData = await (await Cache.init()).getDecodedMetadata(ed.metadata);
         return {
           marketId: ed.market_id,
           encoded: ed.metadata,


### PR DESCRIPTION
Serves as a backup and validation tool for content stored in IPFS. Closes #437. 