### PR TITLE
Digest MarketDisputedEvent without report

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -367,7 +367,7 @@ type MarketReport @jsonField {
   "Account which reported"
   by: String
   "Outcome details"
-  outcome: OutcomeReport!
+  outcome: OutcomeReport
 }
 
 """

--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -436,18 +436,15 @@ export const marketDisputed = async (ctx: Ctx, block: SubstrateBlock, item: Even
   if (!market.disputes) market.disputes = [];
 
   const mr = new MarketReport();
+  mr.at = block.height;
   if (report) {
-    if (report.at) mr.at = +report.at.toString();
     if (report.by) mr.by = ss58.codec('zeitgeist').encode(report.by);
-
-    const ocr = new OutcomeReport();
-    if (report.outcome.__kind == 'Categorical') ocr.categorical = report.outcome.value;
-    else if (report.outcome.__kind == 'Scalar') ocr.scalar = report.outcome.value;
-    mr.outcome = ocr;
-
-    market.disputes.push(mr);
+    const or = new OutcomeReport();
+    if (report.outcome.__kind == 'Categorical') or.categorical = report.outcome.value;
+    else if (report.outcome.__kind == 'Scalar') or.scalar = report.outcome.value;
+    mr.outcome = or;
   }
-
+  market.disputes.push(mr);
   market.status = status ? getMarketStatus(status) : MarketStatus.Disputed;
   console.log(`[${item.event.name}] Saving market: ${JSON.stringify(market, null, 2)}`);
   await ctx.store.save<Market>(market);

--- a/src/mappings/predictionMarkets/types.ts
+++ b/src/mappings/predictionMarkets/types.ts
@@ -141,10 +141,14 @@ export const getMarketDisputedEvent = (ctx: Ctx, item: EventItem): MarketDispute
     const [mId, status, report] = event.asV29;
     const marketId = Number(mId);
     return { marketId, status, report };
-  } else {
-    const [mId, status, report] = item.event.args;
+  } else if (event.isV49) {
+    const [mId, status] = event.asV49;
     const marketId = Number(mId);
-    return { marketId, status, report };
+    return { marketId, status };
+  } else {
+    const [mId, status] = item.event.args;
+    const marketId = Number(mId);
+    return { marketId, status };
   }
 };
 
@@ -323,7 +327,7 @@ interface MarketCreatedEvent {
 interface MarketDisputedEvent {
   marketId: number;
   status?: MarketStatus;
-  report: MarketDispute;
+  report?: MarketDispute;
 }
 
 interface MarketRejectedEvent {

--- a/src/model/generated/_marketReport.ts
+++ b/src/model/generated/_marketReport.ts
@@ -8,14 +8,14 @@ import {OutcomeReport} from "./_outcomeReport"
 export class MarketReport {
     private _at!: number | undefined | null
     private _by!: string | undefined | null
-    private _outcome!: OutcomeReport
+    private _outcome!: OutcomeReport | undefined | null
 
     constructor(props?: Partial<Omit<MarketReport, 'toJSON'>>, json?: any) {
         Object.assign(this, props)
         if (json != null) {
             this._at = json.at == null ? undefined : marshal.int.fromJSON(json.at)
             this._by = json.by == null ? undefined : marshal.string.fromJSON(json.by)
-            this._outcome = new OutcomeReport(undefined, marshal.nonNull(json.outcome))
+            this._outcome = json.outcome == null ? undefined : new OutcomeReport(undefined, json.outcome)
         }
     }
 
@@ -44,12 +44,11 @@ export class MarketReport {
     /**
      * Outcome details
      */
-    get outcome(): OutcomeReport {
-        assert(this._outcome != null, 'uninitialized access')
+    get outcome(): OutcomeReport | undefined | null {
         return this._outcome
     }
 
-    set outcome(value: OutcomeReport) {
+    set outcome(value: OutcomeReport | undefined | null) {
         this._outcome = value
     }
 
@@ -57,7 +56,7 @@ export class MarketReport {
         return {
             at: this.at,
             by: this.by,
-            outcome: this.outcome.toJSON(),
+            outcome: this.outcome == null ? undefined : this.outcome.toJSON(),
         }
     }
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -15,6 +15,7 @@ import * as v41 from './v41'
 import * as v42 from './v42'
 import * as v46 from './v46'
 import * as v47 from './v47'
+import * as v49 from './v49'
 
 export class AssetTxPaymentAssetTxFeePaidEvent {
     private readonly _chain: Chain
@@ -986,6 +987,21 @@ export class PredictionMarketsMarketCreatedEvent {
         assert(this.isV46)
         return this._chain.decodeEvent(this.event)
     }
+
+    /**
+     * A market has been created. \[market_id, market_account, market\]
+     */
+    get isV49(): boolean {
+        return this._chain.getEventHash('PredictionMarkets.MarketCreated') === '53764ddcd3e5dd127a8ff52ec7e3eb8a693f33ec19192a40c74da9091c3bc813'
+    }
+
+    /**
+     * A market has been created. \[market_id, market_account, market\]
+     */
+    get asV49(): [bigint, Uint8Array, v49.Market] {
+        assert(this.isV49)
+        return this._chain.decodeEvent(this.event)
+    }
 }
 
 export class PredictionMarketsMarketDestroyedEvent {
@@ -1057,6 +1073,21 @@ export class PredictionMarketsMarketDisputedEvent {
      */
     get asV29(): [bigint, v29.MarketStatus, v29.MarketDispute] {
         assert(this.isV29)
+        return this._chain.decodeEvent(this.event)
+    }
+
+    /**
+     * A market has been disputed \[market_id, new_market_status\]
+     */
+    get isV49(): boolean {
+        return this._chain.getEventHash('PredictionMarkets.MarketDisputed') === 'fb75141ba1d5569f28a5c37f474643ded3eff690fd78829c343a0a124058d613'
+    }
+
+    /**
+     * A market has been disputed \[market_id, new_market_status\]
+     */
+    get asV49(): [bigint, v49.MarketStatus] {
+        assert(this.isV49)
         return this._chain.decodeEvent(this.event)
     }
 }

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -8,6 +8,7 @@ import * as v41 from './v41'
 import * as v42 from './v42'
 import * as v46 from './v46'
 import * as v48 from './v48'
+import * as v49 from './v49'
 
 export class AssetRegistryMetadataStorage extends StorageBase {
     protected getPrefix() {
@@ -62,6 +63,21 @@ export class AssetRegistryMetadataStorage extends StorageBase {
         assert(this.isV48)
         return this as any
     }
+
+    /**
+     *  The metadata of an asset, indexed by asset id.
+     */
+    get isV49(): boolean {
+        return this.getTypeHash() === 'b5a28fdad27e7ab599284fc6df7a7fe9e948ece74102bdce1eaeac25f43361ee'
+    }
+
+    /**
+     *  The metadata of an asset, indexed by asset id.
+     */
+    get asV49(): AssetRegistryMetadataStorageV49 {
+        assert(this.isV49)
+        return this as any
+    }
 }
 
 /**
@@ -113,6 +129,23 @@ export interface AssetRegistryMetadataStorageV48 {
     getPairs(key: v48.Asset): Promise<[k: v48.Asset, v: v48.AssetMetadata][]>
     getPairsPaged(pageSize: number): AsyncIterable<[k: v48.Asset, v: v48.AssetMetadata][]>
     getPairsPaged(pageSize: number, key: v48.Asset): AsyncIterable<[k: v48.Asset, v: v48.AssetMetadata][]>
+}
+
+/**
+ *  The metadata of an asset, indexed by asset id.
+ */
+export interface AssetRegistryMetadataStorageV49 {
+    get(key: v49.Asset): Promise<(v49.AssetMetadata | undefined)>
+    getAll(): Promise<v49.AssetMetadata[]>
+    getMany(keys: v49.Asset[]): Promise<(v49.AssetMetadata | undefined)[]>
+    getKeys(): Promise<v49.Asset[]>
+    getKeys(key: v49.Asset): Promise<v49.Asset[]>
+    getKeysPaged(pageSize: number): AsyncIterable<v49.Asset[]>
+    getKeysPaged(pageSize: number, key: v49.Asset): AsyncIterable<v49.Asset[]>
+    getPairs(): Promise<[k: v49.Asset, v: v49.AssetMetadata][]>
+    getPairs(key: v49.Asset): Promise<[k: v49.Asset, v: v49.AssetMetadata][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: v49.Asset, v: v49.AssetMetadata][]>
+    getPairsPaged(pageSize: number, key: v49.Asset): AsyncIterable<[k: v49.Asset, v: v49.AssetMetadata][]>
 }
 
 export class MarketCommonsMarketsStorage extends StorageBase {
@@ -226,6 +259,21 @@ export class MarketCommonsMarketsStorage extends StorageBase {
      */
     get asV46(): MarketCommonsMarketsStorageV46 {
         assert(this.isV46)
+        return this as any
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get isV49(): boolean {
+        return this.getTypeHash() === 'f22ea6b3d18a1fc67c234fa2c60ca04f2f2ed1b23e416b25f9b17b8ea50eaebb'
+    }
+
+    /**
+     *  Holds all markets
+     */
+    get asV49(): MarketCommonsMarketsStorageV49 {
+        assert(this.isV49)
         return this as any
     }
 }
@@ -347,4 +395,21 @@ export interface MarketCommonsMarketsStorageV46 {
     getPairs(key: bigint): Promise<[k: bigint, v: v46.Market][]>
     getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v46.Market][]>
     getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v46.Market][]>
+}
+
+/**
+ *  Holds all markets
+ */
+export interface MarketCommonsMarketsStorageV49 {
+    get(key: bigint): Promise<(v49.Market | undefined)>
+    getAll(): Promise<v49.Market[]>
+    getMany(keys: bigint[]): Promise<(v49.Market | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v49.Market][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v49.Market][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v49.Market][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v49.Market][]>
 }

--- a/src/types/v49.ts
+++ b/src/types/v49.ts
@@ -1,0 +1,651 @@
+import type {Result, Option} from './support'
+
+export interface Market {
+    baseAsset: Asset
+    creator: Uint8Array
+    creation: MarketCreation
+    creatorFee: number
+    oracle: Uint8Array
+    metadata: Uint8Array
+    marketType: MarketType
+    period: MarketPeriod
+    deadlines: Deadlines
+    scoringRule: ScoringRule
+    status: MarketStatus
+    report: (Report | undefined)
+    resolvedOutcome: (OutcomeReport | undefined)
+    disputeMechanism: MarketDisputeMechanism
+    bonds: MarketBonds
+}
+
+export type MarketStatus = MarketStatus_Proposed | MarketStatus_Active | MarketStatus_Suspended | MarketStatus_Closed | MarketStatus_CollectingSubsidy | MarketStatus_InsufficientSubsidy | MarketStatus_Reported | MarketStatus_Disputed | MarketStatus_Resolved
+
+export interface MarketStatus_Proposed {
+    __kind: 'Proposed'
+}
+
+export interface MarketStatus_Active {
+    __kind: 'Active'
+}
+
+export interface MarketStatus_Suspended {
+    __kind: 'Suspended'
+}
+
+export interface MarketStatus_Closed {
+    __kind: 'Closed'
+}
+
+export interface MarketStatus_CollectingSubsidy {
+    __kind: 'CollectingSubsidy'
+}
+
+export interface MarketStatus_InsufficientSubsidy {
+    __kind: 'InsufficientSubsidy'
+}
+
+export interface MarketStatus_Reported {
+    __kind: 'Reported'
+}
+
+export interface MarketStatus_Disputed {
+    __kind: 'Disputed'
+}
+
+export interface MarketStatus_Resolved {
+    __kind: 'Resolved'
+}
+
+export type Asset = Asset_CategoricalOutcome | Asset_ScalarOutcome | Asset_CombinatorialOutcome | Asset_PoolShare | Asset_Ztg | Asset_ForeignAsset
+
+export interface Asset_CategoricalOutcome {
+    __kind: 'CategoricalOutcome'
+    value: [bigint, number]
+}
+
+export interface Asset_ScalarOutcome {
+    __kind: 'ScalarOutcome'
+    value: [bigint, ScalarPosition]
+}
+
+export interface Asset_CombinatorialOutcome {
+    __kind: 'CombinatorialOutcome'
+}
+
+export interface Asset_PoolShare {
+    __kind: 'PoolShare'
+    value: bigint
+}
+
+export interface Asset_Ztg {
+    __kind: 'Ztg'
+}
+
+export interface Asset_ForeignAsset {
+    __kind: 'ForeignAsset'
+    value: number
+}
+
+export interface AssetMetadata {
+    decimals: number
+    name: Uint8Array
+    symbol: Uint8Array
+    existentialDeposit: bigint
+    location: (VersionedMultiLocation | undefined)
+    additional: CustomMetadata
+}
+
+export type MarketCreation = MarketCreation_Permissionless | MarketCreation_Advised
+
+export interface MarketCreation_Permissionless {
+    __kind: 'Permissionless'
+}
+
+export interface MarketCreation_Advised {
+    __kind: 'Advised'
+}
+
+export type MarketType = MarketType_Categorical | MarketType_Scalar
+
+export interface MarketType_Categorical {
+    __kind: 'Categorical'
+    value: number
+}
+
+export interface MarketType_Scalar {
+    __kind: 'Scalar'
+    value: RangeInclusive
+}
+
+export type MarketPeriod = MarketPeriod_Block | MarketPeriod_Timestamp
+
+export interface MarketPeriod_Block {
+    __kind: 'Block'
+    value: Range
+}
+
+export interface MarketPeriod_Timestamp {
+    __kind: 'Timestamp'
+    value: Range
+}
+
+export interface Deadlines {
+    gracePeriod: bigint
+    oracleDuration: bigint
+    disputeDuration: bigint
+}
+
+export type ScoringRule = ScoringRule_CPMM | ScoringRule_RikiddoSigmoidFeeMarketEma
+
+export interface ScoringRule_CPMM {
+    __kind: 'CPMM'
+}
+
+export interface ScoringRule_RikiddoSigmoidFeeMarketEma {
+    __kind: 'RikiddoSigmoidFeeMarketEma'
+}
+
+export interface Report {
+    at: bigint
+    by: Uint8Array
+    outcome: OutcomeReport
+}
+
+export type OutcomeReport = OutcomeReport_Categorical | OutcomeReport_Scalar
+
+export interface OutcomeReport_Categorical {
+    __kind: 'Categorical'
+    value: number
+}
+
+export interface OutcomeReport_Scalar {
+    __kind: 'Scalar'
+    value: bigint
+}
+
+export type MarketDisputeMechanism = MarketDisputeMechanism_Authorized | MarketDisputeMechanism_Court | MarketDisputeMechanism_SimpleDisputes
+
+export interface MarketDisputeMechanism_Authorized {
+    __kind: 'Authorized'
+}
+
+export interface MarketDisputeMechanism_Court {
+    __kind: 'Court'
+}
+
+export interface MarketDisputeMechanism_SimpleDisputes {
+    __kind: 'SimpleDisputes'
+}
+
+export interface MarketBonds {
+    creation: (Bond | undefined)
+    oracle: (Bond | undefined)
+    outsider: (Bond | undefined)
+    dispute: (Bond | undefined)
+}
+
+export type ScalarPosition = ScalarPosition_Long | ScalarPosition_Short
+
+export interface ScalarPosition_Long {
+    __kind: 'Long'
+}
+
+export interface ScalarPosition_Short {
+    __kind: 'Short'
+}
+
+export type VersionedMultiLocation = VersionedMultiLocation_V2 | VersionedMultiLocation_V3
+
+export interface VersionedMultiLocation_V2 {
+    __kind: 'V2'
+    value: V2MultiLocation
+}
+
+export interface VersionedMultiLocation_V3 {
+    __kind: 'V3'
+    value: V3MultiLocation
+}
+
+export interface CustomMetadata {
+    xcm: XcmMetadata
+    allowAsBaseAsset: boolean
+}
+
+export interface RangeInclusive {
+    start: bigint
+    end: bigint
+}
+
+export interface Range {
+    start: bigint
+    end: bigint
+}
+
+export interface Bond {
+    who: Uint8Array
+    value: bigint
+    isSettled: boolean
+}
+
+export interface V2MultiLocation {
+    parents: number
+    interior: V2Junctions
+}
+
+export interface V3MultiLocation {
+    parents: number
+    interior: V3Junctions
+}
+
+export interface XcmMetadata {
+    feeFactor: (bigint | undefined)
+}
+
+export type V2Junctions = V2Junctions_Here | V2Junctions_X1 | V2Junctions_X2 | V2Junctions_X3 | V2Junctions_X4 | V2Junctions_X5 | V2Junctions_X6 | V2Junctions_X7 | V2Junctions_X8
+
+export interface V2Junctions_Here {
+    __kind: 'Here'
+}
+
+export interface V2Junctions_X1 {
+    __kind: 'X1'
+    value: V2Junction
+}
+
+export interface V2Junctions_X2 {
+    __kind: 'X2'
+    value: [V2Junction, V2Junction]
+}
+
+export interface V2Junctions_X3 {
+    __kind: 'X3'
+    value: [V2Junction, V2Junction, V2Junction]
+}
+
+export interface V2Junctions_X4 {
+    __kind: 'X4'
+    value: [V2Junction, V2Junction, V2Junction, V2Junction]
+}
+
+export interface V2Junctions_X5 {
+    __kind: 'X5'
+    value: [V2Junction, V2Junction, V2Junction, V2Junction, V2Junction]
+}
+
+export interface V2Junctions_X6 {
+    __kind: 'X6'
+    value: [V2Junction, V2Junction, V2Junction, V2Junction, V2Junction, V2Junction]
+}
+
+export interface V2Junctions_X7 {
+    __kind: 'X7'
+    value: [V2Junction, V2Junction, V2Junction, V2Junction, V2Junction, V2Junction, V2Junction]
+}
+
+export interface V2Junctions_X8 {
+    __kind: 'X8'
+    value: [V2Junction, V2Junction, V2Junction, V2Junction, V2Junction, V2Junction, V2Junction, V2Junction]
+}
+
+export type V3Junctions = V3Junctions_Here | V3Junctions_X1 | V3Junctions_X2 | V3Junctions_X3 | V3Junctions_X4 | V3Junctions_X5 | V3Junctions_X6 | V3Junctions_X7 | V3Junctions_X8
+
+export interface V3Junctions_Here {
+    __kind: 'Here'
+}
+
+export interface V3Junctions_X1 {
+    __kind: 'X1'
+    value: V3Junction
+}
+
+export interface V3Junctions_X2 {
+    __kind: 'X2'
+    value: [V3Junction, V3Junction]
+}
+
+export interface V3Junctions_X3 {
+    __kind: 'X3'
+    value: [V3Junction, V3Junction, V3Junction]
+}
+
+export interface V3Junctions_X4 {
+    __kind: 'X4'
+    value: [V3Junction, V3Junction, V3Junction, V3Junction]
+}
+
+export interface V3Junctions_X5 {
+    __kind: 'X5'
+    value: [V3Junction, V3Junction, V3Junction, V3Junction, V3Junction]
+}
+
+export interface V3Junctions_X6 {
+    __kind: 'X6'
+    value: [V3Junction, V3Junction, V3Junction, V3Junction, V3Junction, V3Junction]
+}
+
+export interface V3Junctions_X7 {
+    __kind: 'X7'
+    value: [V3Junction, V3Junction, V3Junction, V3Junction, V3Junction, V3Junction, V3Junction]
+}
+
+export interface V3Junctions_X8 {
+    __kind: 'X8'
+    value: [V3Junction, V3Junction, V3Junction, V3Junction, V3Junction, V3Junction, V3Junction, V3Junction]
+}
+
+export type V2Junction = V2Junction_Parachain | V2Junction_AccountId32 | V2Junction_AccountIndex64 | V2Junction_AccountKey20 | V2Junction_PalletInstance | V2Junction_GeneralIndex | V2Junction_GeneralKey | V2Junction_OnlyChild | V2Junction_Plurality
+
+export interface V2Junction_Parachain {
+    __kind: 'Parachain'
+    value: number
+}
+
+export interface V2Junction_AccountId32 {
+    __kind: 'AccountId32'
+    network: V2NetworkId
+    id: Uint8Array
+}
+
+export interface V2Junction_AccountIndex64 {
+    __kind: 'AccountIndex64'
+    network: V2NetworkId
+    index: bigint
+}
+
+export interface V2Junction_AccountKey20 {
+    __kind: 'AccountKey20'
+    network: V2NetworkId
+    key: Uint8Array
+}
+
+export interface V2Junction_PalletInstance {
+    __kind: 'PalletInstance'
+    value: number
+}
+
+export interface V2Junction_GeneralIndex {
+    __kind: 'GeneralIndex'
+    value: bigint
+}
+
+export interface V2Junction_GeneralKey {
+    __kind: 'GeneralKey'
+    value: Uint8Array
+}
+
+export interface V2Junction_OnlyChild {
+    __kind: 'OnlyChild'
+}
+
+export interface V2Junction_Plurality {
+    __kind: 'Plurality'
+    id: V2BodyId
+    part: V2BodyPart
+}
+
+export type V3Junction = V3Junction_Parachain | V3Junction_AccountId32 | V3Junction_AccountIndex64 | V3Junction_AccountKey20 | V3Junction_PalletInstance | V3Junction_GeneralIndex | V3Junction_GeneralKey | V3Junction_OnlyChild | V3Junction_Plurality | V3Junction_GlobalConsensus
+
+export interface V3Junction_Parachain {
+    __kind: 'Parachain'
+    value: number
+}
+
+export interface V3Junction_AccountId32 {
+    __kind: 'AccountId32'
+    network: (V3NetworkId | undefined)
+    id: Uint8Array
+}
+
+export interface V3Junction_AccountIndex64 {
+    __kind: 'AccountIndex64'
+    network: (V3NetworkId | undefined)
+    index: bigint
+}
+
+export interface V3Junction_AccountKey20 {
+    __kind: 'AccountKey20'
+    network: (V3NetworkId | undefined)
+    key: Uint8Array
+}
+
+export interface V3Junction_PalletInstance {
+    __kind: 'PalletInstance'
+    value: number
+}
+
+export interface V3Junction_GeneralIndex {
+    __kind: 'GeneralIndex'
+    value: bigint
+}
+
+export interface V3Junction_GeneralKey {
+    __kind: 'GeneralKey'
+    length: number
+    data: Uint8Array
+}
+
+export interface V3Junction_OnlyChild {
+    __kind: 'OnlyChild'
+}
+
+export interface V3Junction_Plurality {
+    __kind: 'Plurality'
+    id: V3BodyId
+    part: V3BodyPart
+}
+
+export interface V3Junction_GlobalConsensus {
+    __kind: 'GlobalConsensus'
+    value: V3NetworkId
+}
+
+export type V2NetworkId = V2NetworkId_Any | V2NetworkId_Named | V2NetworkId_Polkadot | V2NetworkId_Kusama
+
+export interface V2NetworkId_Any {
+    __kind: 'Any'
+}
+
+export interface V2NetworkId_Named {
+    __kind: 'Named'
+    value: Uint8Array
+}
+
+export interface V2NetworkId_Polkadot {
+    __kind: 'Polkadot'
+}
+
+export interface V2NetworkId_Kusama {
+    __kind: 'Kusama'
+}
+
+export type V2BodyId = V2BodyId_Unit | V2BodyId_Named | V2BodyId_Index | V2BodyId_Executive | V2BodyId_Technical | V2BodyId_Legislative | V2BodyId_Judicial | V2BodyId_Defense | V2BodyId_Administration | V2BodyId_Treasury
+
+export interface V2BodyId_Unit {
+    __kind: 'Unit'
+}
+
+export interface V2BodyId_Named {
+    __kind: 'Named'
+    value: Uint8Array
+}
+
+export interface V2BodyId_Index {
+    __kind: 'Index'
+    value: number
+}
+
+export interface V2BodyId_Executive {
+    __kind: 'Executive'
+}
+
+export interface V2BodyId_Technical {
+    __kind: 'Technical'
+}
+
+export interface V2BodyId_Legislative {
+    __kind: 'Legislative'
+}
+
+export interface V2BodyId_Judicial {
+    __kind: 'Judicial'
+}
+
+export interface V2BodyId_Defense {
+    __kind: 'Defense'
+}
+
+export interface V2BodyId_Administration {
+    __kind: 'Administration'
+}
+
+export interface V2BodyId_Treasury {
+    __kind: 'Treasury'
+}
+
+export type V2BodyPart = V2BodyPart_Voice | V2BodyPart_Members | V2BodyPart_Fraction | V2BodyPart_AtLeastProportion | V2BodyPart_MoreThanProportion
+
+export interface V2BodyPart_Voice {
+    __kind: 'Voice'
+}
+
+export interface V2BodyPart_Members {
+    __kind: 'Members'
+    count: number
+}
+
+export interface V2BodyPart_Fraction {
+    __kind: 'Fraction'
+    nom: number
+    denom: number
+}
+
+export interface V2BodyPart_AtLeastProportion {
+    __kind: 'AtLeastProportion'
+    nom: number
+    denom: number
+}
+
+export interface V2BodyPart_MoreThanProportion {
+    __kind: 'MoreThanProportion'
+    nom: number
+    denom: number
+}
+
+export type V3NetworkId = V3NetworkId_ByGenesis | V3NetworkId_ByFork | V3NetworkId_Polkadot | V3NetworkId_Kusama | V3NetworkId_Westend | V3NetworkId_Rococo | V3NetworkId_Wococo | V3NetworkId_Ethereum | V3NetworkId_BitcoinCore | V3NetworkId_BitcoinCash
+
+export interface V3NetworkId_ByGenesis {
+    __kind: 'ByGenesis'
+    value: Uint8Array
+}
+
+export interface V3NetworkId_ByFork {
+    __kind: 'ByFork'
+    blockNumber: bigint
+    blockHash: Uint8Array
+}
+
+export interface V3NetworkId_Polkadot {
+    __kind: 'Polkadot'
+}
+
+export interface V3NetworkId_Kusama {
+    __kind: 'Kusama'
+}
+
+export interface V3NetworkId_Westend {
+    __kind: 'Westend'
+}
+
+export interface V3NetworkId_Rococo {
+    __kind: 'Rococo'
+}
+
+export interface V3NetworkId_Wococo {
+    __kind: 'Wococo'
+}
+
+export interface V3NetworkId_Ethereum {
+    __kind: 'Ethereum'
+    chainId: bigint
+}
+
+export interface V3NetworkId_BitcoinCore {
+    __kind: 'BitcoinCore'
+}
+
+export interface V3NetworkId_BitcoinCash {
+    __kind: 'BitcoinCash'
+}
+
+export type V3BodyId = V3BodyId_Unit | V3BodyId_Moniker | V3BodyId_Index | V3BodyId_Executive | V3BodyId_Technical | V3BodyId_Legislative | V3BodyId_Judicial | V3BodyId_Defense | V3BodyId_Administration | V3BodyId_Treasury
+
+export interface V3BodyId_Unit {
+    __kind: 'Unit'
+}
+
+export interface V3BodyId_Moniker {
+    __kind: 'Moniker'
+    value: Uint8Array
+}
+
+export interface V3BodyId_Index {
+    __kind: 'Index'
+    value: number
+}
+
+export interface V3BodyId_Executive {
+    __kind: 'Executive'
+}
+
+export interface V3BodyId_Technical {
+    __kind: 'Technical'
+}
+
+export interface V3BodyId_Legislative {
+    __kind: 'Legislative'
+}
+
+export interface V3BodyId_Judicial {
+    __kind: 'Judicial'
+}
+
+export interface V3BodyId_Defense {
+    __kind: 'Defense'
+}
+
+export interface V3BodyId_Administration {
+    __kind: 'Administration'
+}
+
+export interface V3BodyId_Treasury {
+    __kind: 'Treasury'
+}
+
+export type V3BodyPart = V3BodyPart_Voice | V3BodyPart_Members | V3BodyPart_Fraction | V3BodyPart_AtLeastProportion | V3BodyPart_MoreThanProportion
+
+export interface V3BodyPart_Voice {
+    __kind: 'Voice'
+}
+
+export interface V3BodyPart_Members {
+    __kind: 'Members'
+    count: number
+}
+
+export interface V3BodyPart_Fraction {
+    __kind: 'Fraction'
+    nom: number
+    denom: number
+}
+
+export interface V3BodyPart_AtLeastProportion {
+    __kind: 'AtLeastProportion'
+    nom: number
+    denom: number
+}
+
+export interface V3BodyPart_MoreThanProportion {
+    __kind: 'MoreThanProportion'
+    nom: number
+    denom: number
+}


### PR DESCRIPTION
`PredictionMarkets.MarketDisputed` event can be handled without report. 

**Fixes**
![Screenshot_2023-10-13_at_3 13 42_PM](https://github.com/zeitgeistpm/zeitgeist-subsquid/assets/36529278/9d11492e-96bc-4ed9-a299-251909246440)

**Based on https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fbsr.zeitgeist.pm#/explorer/query/4292260**

![Screenshot_2023-10-13_at_4 07 57_PM](https://github.com/zeitgeistpm/zeitgeist-subsquid/assets/36529278/3d73594a-fad6-4688-8346-d4f426359064)
