### PR TITLE
Init latest types for AssetRegistryMetadataStorage

### DIFF
--- a/src/mappings/assetTxPayment/index.ts
+++ b/src/mappings/assetTxPayment/index.ts
@@ -1,7 +1,7 @@
 import { SubstrateBlock } from '@subsquid/substrate-processor';
 import { Ctx, EventItem } from '../../processor';
 import { Account, HistoricalAccountBalance } from '../../model';
-import { Asset_ForeignAsset } from '../../types/v48';
+import { Asset_ForeignAsset } from '../../types/v49';
 import { extrinsicFromEvent, getAssetId, initBalance } from '../helper';
 import { getAssetTxFeePaidEvent, getMetadataStorage } from './types';
 

--- a/src/mappings/assetTxPayment/types.ts
+++ b/src/mappings/assetTxPayment/types.ts
@@ -4,7 +4,8 @@ import * as ss58 from '@subsquid/ss58';
 import { Ctx, EventItem } from '../../processor';
 import { AssetTxPaymentAssetTxFeePaidEvent } from '../../types/events';
 import { AssetRegistryMetadataStorage } from '../../types/storage';
-import { AssetMetadata, Asset_ForeignAsset } from '../../types/v48';
+import { AssetMetadata as AssetMetadata_v48 } from '../../types/v48';
+import { AssetMetadata as AssetMetadata_v49, Asset_ForeignAsset } from '../../types/v49';
 
 export const getAssetTxFeePaidEvent = (ctx: Ctx, item: EventItem): AssetTxFeePaidEvent => {
   // @ts-ignore
@@ -29,13 +30,16 @@ export const getMetadataStorage = async (
   ctx: Ctx,
   block: SubstrateBlock,
   assetId: Asset_ForeignAsset
-): Promise<AssetMetadata | undefined> => {
+): Promise<AssetMetadata_v48 | AssetMetadata_v49 | undefined> => {
   const storage = new AssetRegistryMetadataStorage(ctx, block);
   if (storage.isV42) {
     const assetMetadata = await storage.asV42.get(assetId);
     return assetMetadata;
   } else if (storage.isV48) {
     const assetMetadata = await storage.asV48.get(assetId);
+    return assetMetadata;
+  } else {
+    const assetMetadata = await storage.asV49.get(assetId);
     return assetMetadata;
   }
 };


### PR DESCRIPTION
Adapt to incoming  `specVersion:49` changes for storage call AssetRegistryMetadataStorage connected to event `AssetTxPayment.AssetTxFeePaid`. This should debug mapping of the event. 