### PR TITLE
Process `Swaps.MarketCreatorFeesPaid`

### DIFF
--- a/src/mappings/balances/index.ts
+++ b/src/mappings/balances/index.ts
@@ -223,8 +223,13 @@ export const balancesSlashed = async (ctx: Ctx, block: SubstrateBlock, item: Eve
   }
 };
 
-export const balancesTransfer = async (ctx: Ctx, block: SubstrateBlock, item: EventItem): Promise<Transfer> => {
+export const balancesTransfer = async (
+  ctx: Ctx,
+  block: SubstrateBlock,
+  item: EventItem
+): Promise<HistoricalAccountBalance[]> => {
   const { fromId, toId, amount } = getTransferEvent(ctx, item);
+  const habs: HistoricalAccountBalance[] = [];
 
   let fromAcc = await ctx.store.get(Account, { where: { accountId: fromId } });
   if (!fromAcc) {
@@ -245,6 +250,7 @@ export const balancesTransfer = async (ctx: Ctx, block: SubstrateBlock, item: Ev
   fromHab.dBalance = -amount;
   fromHab.blockNumber = block.height;
   fromHab.timestamp = new Date(block.timestamp);
+  habs.push(fromHab);
 
   let toAcc = await ctx.store.get(Account, { where: { accountId: toId } });
   if (!toAcc) {
@@ -265,8 +271,9 @@ export const balancesTransfer = async (ctx: Ctx, block: SubstrateBlock, item: Ev
   toHab.dBalance = amount;
   toHab.blockNumber = block.height;
   toHab.timestamp = new Date(block.timestamp);
+  habs.push(toHab);
 
-  return { fromHab, toHab };
+  return habs;
 };
 
 export const balancesUnreserved = async (

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -391,13 +391,14 @@ processor.run(new TypeormDatabase(), async (ctx) => {
             break;
           }
           case 'Balances.Transfer': {
-            const res = await balancesTransfer(ctx, block.header, item);
-            const fromKey = makeKey(res.fromHab.accountId, res.fromHab.assetId);
-            const toKey = makeKey(res.toHab.accountId, res.toHab.assetId);
-            balanceAccounts.set(fromKey, (balanceAccounts.get(fromKey) || BigInt(0)) + res.fromHab.dBalance);
-            balanceAccounts.set(toKey, (balanceAccounts.get(toKey) || BigInt(0)) + res.toHab.dBalance);
-            balanceHistory.push(res.fromHab);
-            balanceHistory.push(res.toHab);
+            const habs = await balancesTransfer(ctx, block.header, item);
+            await Promise.all(
+              habs.map(async (hab) => {
+                const key = makeKey(hab.accountId, hab.assetId);
+                balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+                balanceHistory.push(hab);
+              })
+            );
             break;
           }
           case 'Balances.Unreserved': {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -154,6 +154,7 @@ const processor = new SubstrateBatchProcessor()
   .addEvent('Styx.AccountCrossed', eventExtrinsicOptions)
   .addEvent('Swaps.ArbitrageBuyBurn', eventOptions)
   .addEvent('Swaps.ArbitrageMintSell', eventOptions)
+  .addEvent('Swaps.MarketCreatorFeesPaid', eventOptions)
   .addEvent('Swaps.PoolActive', eventOptions)
   .addEvent('Swaps.PoolClosed', eventOptions)
   .addEvent('Swaps.PoolCreate', eventOptions)
@@ -508,6 +509,19 @@ processor.run(new TypeormDatabase(), async (ctx) => {
             await saveBalanceChanges(ctx, balanceAccounts);
             balanceAccounts.clear();
             await arbitrageMintSell(ctx, block.header, item);
+            break;
+          }
+          case 'Swaps.MarketCreatorFeesPaid': {
+            const newHabs: HistoricalAccountBalance[] = [];
+            for (let i = 0; i < 2; i++) {
+              const hab = balanceHistory.pop();
+              if (hab && hab.event === 'Transfer') {
+                hab.id = item.event.id + hab.id.slice(-6);
+                hab.event = item.event.name.split('.')[1];
+                newHabs.push(hab);
+              }
+            }
+            balanceHistory.push(...newHabs);
             break;
           }
           case 'Swaps.PoolCreate': {


### PR DESCRIPTION
As noticed, each event `Swaps.MarketCreatorFeesPaid` accompanies with the event `Balances.Transfer` to capture same transaction. Sequentially, it means that `BalancesTransferEvent` would be processed before `SwapsMarketCreatorFeesPaidEvent`. 

This PR refurbishes the already processed record. Closes #434.

<img width="491" alt="Screenshot 2023-10-15 at 3 11 00 PM" src="https://github.com/zeitgeistpm/zeitgeist-subsquid/assets/36529278/2161a3bb-3949-437f-9d78-f094ba6bec39">
