### PR TITLE
Record asset txn fee deposits in treasury account

### DIFF
--- a/src/mappings/assetTxPayment/index.ts
+++ b/src/mappings/assetTxPayment/index.ts
@@ -2,7 +2,7 @@ import { SubstrateBlock } from '@subsquid/substrate-processor';
 import { Ctx, EventItem } from '../../processor';
 import { HistoricalAccountBalance } from '../../model';
 import { Asset_ForeignAsset } from '../../types/v49';
-import { extrinsicFromEvent, getAssetId } from '../helper';
+import { TREASURY_ACCOUNT, extrinsicFromEvent, getAssetId } from '../helper';
 import { getAssetTxFeePaidEvent, getMetadataStorage } from './types';
 
 export const assetTxPaymentAssetTxFeePaidEvent = async (
@@ -30,8 +30,8 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
   });
 
   const treasuryHab = new HistoricalAccountBalance({
-    id: item.event.id + '-' + walletId.slice(-5),
-    accountId: 'dE1VdxVn8xy7HFQG5y5px7T2W1TDpRq1QXHH2ozfZLhBMYiBJ',
+    id: item.event.id + '-' + TREASURY_ACCOUNT.slice(-5),
+    accountId: TREASURY_ACCOUNT,
     assetId: getAssetId(currencyId),
     blockNumber: block.height,
     dBalance: BigInt(Math.round(amount)),

--- a/src/mappings/assetTxPayment/index.ts
+++ b/src/mappings/assetTxPayment/index.ts
@@ -2,7 +2,7 @@ import { SubstrateBlock } from '@subsquid/substrate-processor';
 import { Ctx, EventItem } from '../../processor';
 import { HistoricalAccountBalance } from '../../model';
 import { Asset_ForeignAsset } from '../../types/v49';
-import { TREASURY_ACCOUNT, extrinsicFromEvent, getAssetId } from '../helper';
+import { TREASURY_ACCOUNT, extrinsicFromEvent, getAssetId, specVersion } from '../helper';
 import { getAssetTxFeePaidEvent, getMetadataStorage } from './types';
 
 export const assetTxPaymentAssetTxFeePaidEvent = async (
@@ -28,6 +28,10 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
     extrinsic: extrinsicFromEvent(item.event),
     timestamp: new Date(block.timestamp),
   });
+  habs.push(userHab);
+
+  if (process.env.WS_NODE_URL?.includes(`bs`) && specVersion(block.specId) < 49)
+    if (assetId == 0 || assetId == 2) return habs;
 
   const treasuryHab = new HistoricalAccountBalance({
     id: item.event.id + '-' + TREASURY_ACCOUNT.slice(-5),
@@ -39,7 +43,7 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
     extrinsic: extrinsicFromEvent(item.event),
     timestamp: new Date(block.timestamp),
   });
+  habs.push(treasuryHab);
 
-  habs.push(userHab, treasuryHab);
   return habs;
 };

--- a/src/mappings/assetTxPayment/index.ts
+++ b/src/mappings/assetTxPayment/index.ts
@@ -9,23 +9,37 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
   ctx: Ctx,
   block: SubstrateBlock,
   item: EventItem
-): Promise<HistoricalAccountBalance | undefined> => {
+): Promise<HistoricalAccountBalance[] | undefined> => {
   const { walletId, actualFee, assetId } = getAssetTxFeePaidEvent(ctx, item);
   const currencyId: Asset_ForeignAsset = { __kind: 'ForeignAsset', value: assetId };
+  const habs: HistoricalAccountBalance[] = [];
 
   const onChainAsset = await getMetadataStorage(ctx, block, currencyId);
   if (!onChainAsset || !onChainAsset.additional.xcm.feeFactor) return;
   const amount = (Number(actualFee) * Number(onChainAsset.additional.xcm.feeFactor)) / 10 ** 10;
 
-  const hab = new HistoricalAccountBalance();
-  hab.id = item.event.id + '-' + walletId.slice(-5);
-  hab.accountId = walletId;
-  hab.event = item.event.name.split('.')[1];
-  hab.extrinsic = extrinsicFromEvent(item.event);
-  hab.assetId = getAssetId(currencyId);
-  hab.dBalance = -BigInt(Math.round(amount));
-  hab.blockNumber = block.height;
-  hab.timestamp = new Date(block.timestamp);
+  const userHab: HistoricalAccountBalance = {
+    id: item.event.id + '-' + walletId.slice(-5),
+    accountId: walletId,
+    assetId: getAssetId(currencyId),
+    blockNumber: block.height,
+    dBalance: -BigInt(Math.round(amount)),
+    event: item.event.name.split('.')[1],
+    extrinsic: extrinsicFromEvent(item.event),
+    timestamp: new Date(block.timestamp),
+  };
 
-  return hab;
+  const treasuryHab: HistoricalAccountBalance = {
+    id: item.event.id + '-' + walletId.slice(-5),
+    accountId: 'dE1VdxVn8xy7HFQG5y5px7T2W1TDpRq1QXHH2ozfZLhBMYiBJ',
+    assetId: getAssetId(currencyId),
+    blockNumber: block.height,
+    dBalance: BigInt(Math.round(amount)),
+    event: item.event.name.split('.')[1],
+    extrinsic: extrinsicFromEvent(item.event),
+    timestamp: new Date(block.timestamp),
+  };
+
+  habs.push(userHab, treasuryHab);
+  return habs;
 };

--- a/src/mappings/assetTxPayment/index.ts
+++ b/src/mappings/assetTxPayment/index.ts
@@ -34,7 +34,7 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
   if (process.env.WS_NODE_URL?.includes(`bs`) && specVersion(block.specId) < 49)
     if (assetId == 0 || assetId == 2) return habs;
 
-  // Deposit transaction fees to treasury account (against TokensBalanceSetEvent noticed on-chain)
+  // Record TokensBalanceSetEvent for txn fee deposits in treasury account
   const treasuryHab = new HistoricalAccountBalance({
     id: item.event.id + '-' + TREASURY_ACCOUNT.slice(-5),
     accountId: TREASURY_ACCOUNT,

--- a/src/mappings/assetTxPayment/index.ts
+++ b/src/mappings/assetTxPayment/index.ts
@@ -30,9 +30,11 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
   });
   habs.push(userHab);
 
+  // Skip condition. Ref: https://github.com/zeitgeistpm/zeitgeist/issues/1091
   if (process.env.WS_NODE_URL?.includes(`bs`) && specVersion(block.specId) < 49)
     if (assetId == 0 || assetId == 2) return habs;
 
+  // Deposit transaction fees to treasury account (against TokensBalanceSetEvent noticed on-chain)
   const treasuryHab = new HistoricalAccountBalance({
     id: item.event.id + '-' + TREASURY_ACCOUNT.slice(-5),
     accountId: TREASURY_ACCOUNT,

--- a/src/mappings/assetTxPayment/index.ts
+++ b/src/mappings/assetTxPayment/index.ts
@@ -18,7 +18,7 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
   if (!onChainAsset || !onChainAsset.additional.xcm.feeFactor) return;
   const amount = (Number(actualFee) * Number(onChainAsset.additional.xcm.feeFactor)) / 10 ** 10;
 
-  const userHab: HistoricalAccountBalance = {
+  const userHab = new HistoricalAccountBalance({
     id: item.event.id + '-' + walletId.slice(-5),
     accountId: walletId,
     assetId: getAssetId(currencyId),
@@ -27,9 +27,9 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
     event: item.event.name.split('.')[1],
     extrinsic: extrinsicFromEvent(item.event),
     timestamp: new Date(block.timestamp),
-  };
+  });
 
-  const treasuryHab: HistoricalAccountBalance = {
+  const treasuryHab = new HistoricalAccountBalance({
     id: item.event.id + '-' + walletId.slice(-5),
     accountId: 'dE1VdxVn8xy7HFQG5y5px7T2W1TDpRq1QXHH2ozfZLhBMYiBJ',
     assetId: getAssetId(currencyId),
@@ -38,7 +38,7 @@ export const assetTxPaymentAssetTxFeePaidEvent = async (
     event: item.event.name.split('.')[1],
     extrinsic: extrinsicFromEvent(item.event),
     timestamp: new Date(block.timestamp),
-  };
+  });
 
   habs.push(userHab, treasuryHab);
   return habs;

--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -12,10 +12,11 @@ import {
   MarketStatus,
   PoolStatus,
 } from '../model';
-import { EventItem } from '../processor';
 import { PoolStatus as _PoolStatus } from '../types/v41';
 import { Asset, MarketCreation as _MarketCreation, MarketStatus as _MarketStatus } from '../types/v42';
 import { Cache, IPFS, Tools } from './util';
+
+export const TREASURY_ACCOUNT = 'dE1VdxVn8xy7HFQG5y5px7T2W1TDpRq1QXHH2ozfZLhBMYiBJ';
 
 export const calcSpotPrice = (
   tokenBalanceIn: number,

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -347,11 +347,15 @@ processor.run(new TypeormDatabase(), async (ctx) => {
       if (item.kind === 'event') {
         switch (item.name) {
           case 'AssetTxPayment.AssetTxFeePaid': {
-            const hab = await assetTxPaymentAssetTxFeePaidEvent(ctx, block.header, item);
-            if (hab) {
-              const key = makeKey(hab.accountId, hab.assetId);
-              balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
-              balanceHistory.push(hab);
+            const habs = await assetTxPaymentAssetTxFeePaidEvent(ctx, block.header, item);
+            if (habs) {
+              await Promise.all(
+                habs.map(async (hab) => {
+                  const key = makeKey(hab.accountId, hab.assetId);
+                  balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+                  balanceHistory.push(hab);
+                })
+              );
             }
             break;
           }


### PR DESCRIPTION
As noticed [on-chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fbsr.zeitgeist.pm#/explorer/query/4287409), transaction fees recorded by event `AssetTxPayment.AssetTxFeePaid` are collected by the treasury account.