### PR TITLE
Ensure types coverage above specVersion:51

### DIFF
--- a/src/mappings/currency/index.ts
+++ b/src/mappings/currency/index.ts
@@ -1,7 +1,7 @@
 import { SubstrateBlock } from '@subsquid/substrate-processor';
 import { HistoricalAccountBalance } from '../../model';
 import { Ctx, EventItem } from '../../processor';
-import { extrinsicFromEvent, Transfer } from '../helper';
+import { extrinsicFromEvent } from '../helper';
 import { getDepositedEvent, getTransferredEvent, getWithdrawnEvent } from './types';
 
 export const currencyDeposited = async (
@@ -28,9 +28,10 @@ export const currencyTransferred = async (
   ctx: Ctx,
   block: SubstrateBlock,
   item: EventItem
-): Promise<Transfer | undefined> => {
+): Promise<HistoricalAccountBalance[] | undefined> => {
   const { assetId, fromId, toId, amount } = getTransferredEvent(ctx, item);
   if (assetId === 'Ztg') return;
+  const habs: HistoricalAccountBalance[] = [];
 
   const fromHab = new HistoricalAccountBalance();
   fromHab.id = item.event.id + '-' + fromId.slice(-5);
@@ -52,7 +53,8 @@ export const currencyTransferred = async (
   toHab.blockNumber = block.height;
   toHab.timestamp = new Date(block.timestamp);
 
-  return { fromHab, toHab };
+  habs.push(fromHab, toHab);
+  return habs;
 };
 
 export const currencyWithdrawn = async (

--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -302,8 +302,3 @@ interface DecodedMarketMetadata {
   img?: string;
   scalarType?: string;
 }
-
-export interface Transfer {
-  fromHab: HistoricalAccountBalance;
-  toHab: HistoricalAccountBalance;
-}

--- a/src/mappings/tokens/index.ts
+++ b/src/mappings/tokens/index.ts
@@ -1,7 +1,7 @@
 import { SubstrateBlock } from '@subsquid/substrate-processor';
 import { Account, AccountBalance, HistoricalAccountBalance } from '../../model';
 import { Ctx, EventItem } from '../../processor';
-import { extrinsicFromEvent, Transfer } from '../helper';
+import { extrinsicFromEvent } from '../helper';
 import {
   getTokensBalanceSetEvent,
   getTokensDepositedEvent,
@@ -68,8 +68,13 @@ export const tokensDeposited = async (
   return hab;
 };
 
-export const tokensTransfer = async (ctx: Ctx, block: SubstrateBlock, item: EventItem): Promise<Transfer> => {
+export const tokensTransfer = async (
+  ctx: Ctx,
+  block: SubstrateBlock,
+  item: EventItem
+): Promise<HistoricalAccountBalance[]> => {
   const { assetId, fromId, toId, amount } = getTokensTransferEvent(ctx, item);
+  const habs: HistoricalAccountBalance[] = [];
 
   const fromHab = new HistoricalAccountBalance();
   fromHab.id = item.event.id + '-' + fromId.slice(-5);
@@ -91,7 +96,8 @@ export const tokensTransfer = async (ctx: Ctx, block: SubstrateBlock, item: Even
   toHab.blockNumber = block.height;
   toHab.timestamp = new Date(block.timestamp);
 
-  return { fromHab, toHab };
+  habs.push(fromHab, toHab);
+  return habs;
 };
 
 export const tokensWithdrawn = async (

--- a/src/mappings/tokens/types.ts
+++ b/src/mappings/tokens/types.ts
@@ -37,7 +37,7 @@ export const getTokensBalanceSetEvent = (ctx: Ctx, item: EventItem): TokensEvent
 
 export const getTokensDepositedEvent = (ctx: Ctx, item: EventItem): TokensEvent => {
   const event = new TokensDepositedEvent(ctx, item.event);
-  let currencyId, walletId, who, amount;
+  let currencyId, walletId, amount;
   if (event.isV36) {
     currencyId = event.asV36.currencyId;
     walletId = ss58.codec('zeitgeist').encode(event.asV36.who);
@@ -47,8 +47,9 @@ export const getTokensDepositedEvent = (ctx: Ctx, item: EventItem): TokensEvent 
     walletId = ss58.codec('zeitgeist').encode(event.asV41.who);
     amount = event.asV41.amount;
   } else {
-    [currencyId, who, amount] = item.event.args;
-    walletId = encodeAddress(who, 73);
+    currencyId = item.event.args.currencyId;
+    walletId = encodeAddress(item.event.args.who, 73);
+    amount = BigInt(item.event.args.amount);
   }
   const assetId = formatAssetId(currencyId);
   return { assetId, walletId, amount };
@@ -76,9 +77,10 @@ export const getTokensTransferEvent = (ctx: Ctx, item: EventItem): TransferEvent
     toId = ss58.codec('zeitgeist').encode(event.asV41.to);
     amount = event.asV41.amount;
   } else {
-    [currencyId, from, to, amount] = item.event.args;
-    fromId = encodeAddress(from, 73);
-    toId = encodeAddress(to, 73);
+    currencyId = item.event.args.currencyId;
+    fromId = encodeAddress(item.event.args.from, 73);
+    toId = encodeAddress(item.event.args.to, 73);
+    amount = BigInt(item.event.args.amount);
   }
   const assetId = formatAssetId(currencyId);
   return { assetId, fromId, toId, amount };
@@ -96,8 +98,9 @@ export const getTokensWithdrawnEvent = (ctx: Ctx, item: EventItem): TokensEvent 
     walletId = ss58.codec('zeitgeist').encode(event.asV41.who);
     amount = event.asV41.amount;
   } else {
-    [currencyId, who, amount] = item.event.args;
-    walletId = encodeAddress(who, 73);
+    currencyId = item.event.args.currencyId;
+    walletId = encodeAddress(item.event.args.who, 73);
+    amount = BigInt(item.event.args.amount);
   }
   const assetId = formatAssetId(currencyId);
   return { assetId, walletId, amount };

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -358,15 +358,14 @@ processor.run(new TypeormDatabase(), async (ctx) => {
         switch (item.name) {
           case 'AssetTxPayment.AssetTxFeePaid': {
             const habs = await assetTxPaymentAssetTxFeePaidEvent(ctx, block.header, item);
-            if (habs) {
-              await Promise.all(
-                habs.map(async (hab) => {
-                  const key = makeKey(hab.accountId, hab.assetId);
-                  balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
-                  balanceHistory.push(hab);
-                })
-              );
-            }
+            if (!habs) break;
+            await Promise.all(
+              habs.map(async (hab) => {
+                const key = makeKey(hab.accountId, hab.assetId);
+                balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+                balanceHistory.push(hab);
+              })
+            );
             break;
           }
           case 'Balances.BalanceSet': {
@@ -398,11 +397,10 @@ processor.run(new TypeormDatabase(), async (ctx) => {
           }
           case 'Balances.ReserveRepatriated': {
             const hab = await balancesReserveRepatriated(ctx, block.header, item);
-            if (hab) {
-              const key = makeKey(hab.accountId, hab.assetId);
-              balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
-              balanceHistory.push(hab);
-            }
+            if (!hab) break;
+            const key = makeKey(hab.accountId, hab.assetId);
+            balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+            balanceHistory.push(hab);
             break;
           }
           case 'Balances.Transfer': {
@@ -431,15 +429,15 @@ processor.run(new TypeormDatabase(), async (ctx) => {
             break;
           }
           case 'Currency.Transferred': {
-            const res = await currencyTransferred(ctx, block.header, item);
-            if (res) {
-              const fromKey = makeKey(res.fromHab.accountId, res.fromHab.assetId);
-              const toKey = makeKey(res.toHab.accountId, res.toHab.assetId);
-              balanceAccounts.set(fromKey, (balanceAccounts.get(fromKey) || BigInt(0)) + res.fromHab.dBalance);
-              balanceAccounts.set(toKey, (balanceAccounts.get(toKey) || BigInt(0)) + res.toHab.dBalance);
-              balanceHistory.push(res.fromHab);
-              balanceHistory.push(res.toHab);
-            }
+            const habs = await currencyTransferred(ctx, block.header, item);
+            if (!habs) break;
+            await Promise.all(
+              habs.map(async (hab) => {
+                const key = makeKey(hab.accountId, hab.assetId);
+                balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+                balanceHistory.push(hab);
+              })
+            );
             break;
           }
           case 'Currency.Deposited': {
@@ -476,15 +474,14 @@ processor.run(new TypeormDatabase(), async (ctx) => {
           }
           case 'PredictionMarkets.BoughtCompleteSet': {
             const habs = await boughtCompleteSet(ctx, block.header, item);
-            if (habs) {
-              await Promise.all(
-                habs.map(async (hab) => {
-                  const key = makeKey(hab.accountId, hab.assetId);
-                  balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
-                  balanceHistory.push(hab);
-                })
-              );
-            }
+            if (!habs) break;
+            await Promise.all(
+              habs.map(async (hab) => {
+                const key = makeKey(hab.accountId, hab.assetId);
+                balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+                balanceHistory.push(hab);
+              })
+            );
             break;
           }
           case 'PredictionMarkets.MarketResolved': {
@@ -495,15 +492,14 @@ processor.run(new TypeormDatabase(), async (ctx) => {
           }
           case 'PredictionMarkets.SoldCompleteSet': {
             const habs = await soldCompleteSet(ctx, block.header, item);
-            if (habs) {
-              await Promise.all(
-                habs.map(async (hab) => {
-                  const key = makeKey(hab.accountId, hab.assetId);
-                  balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
-                  balanceHistory.push(hab);
-                })
-              );
-            }
+            if (!habs) break;
+            await Promise.all(
+              habs.map(async (hab) => {
+                const key = makeKey(hab.accountId, hab.assetId);
+                balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+                balanceHistory.push(hab);
+              })
+            );
             break;
           }
           case 'PredictionMarkets.TokensRedeemed': {
@@ -634,21 +630,19 @@ processor.run(new TypeormDatabase(), async (ctx) => {
           // @ts-ignore
           case 'System.ExtrinsicFailed': {
             const hab = await systemExtrinsicFailed(ctx, block.header, item);
-            if (hab) {
-              const key = makeKey(hab.accountId, hab.assetId);
-              balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
-              balanceHistory.push(hab);
-            }
+            if (!hab) break;
+            const key = makeKey(hab.accountId, hab.assetId);
+            balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+            balanceHistory.push(hab);
             break;
           }
           // @ts-ignore
           case 'System.ExtrinsicSuccess': {
             const hab = await systemExtrinsicSuccess(ctx, block.header, item);
-            if (hab) {
-              const key = makeKey(hab.accountId, hab.assetId);
-              balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
-              balanceHistory.push(hab);
-            }
+            if (!hab) break;
+            const key = makeKey(hab.accountId, hab.assetId);
+            balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+            balanceHistory.push(hab);
             break;
           }
           case 'Tokens.BalanceSet': {
@@ -665,13 +659,14 @@ processor.run(new TypeormDatabase(), async (ctx) => {
             break;
           }
           case 'Tokens.Transfer': {
-            const res = await tokensTransfer(ctx, block.header, item);
-            const fromKey = makeKey(res.fromHab.accountId, res.fromHab.assetId);
-            const toKey = makeKey(res.toHab.accountId, res.toHab.assetId);
-            balanceAccounts.set(fromKey, (balanceAccounts.get(fromKey) || BigInt(0)) + res.fromHab.dBalance);
-            balanceAccounts.set(toKey, (balanceAccounts.get(toKey) || BigInt(0)) + res.toHab.dBalance);
-            balanceHistory.push(res.fromHab);
-            balanceHistory.push(res.toHab);
+            const habs = await tokensTransfer(ctx, block.header, item);
+            await Promise.all(
+              habs.map(async (hab) => {
+                const key = makeKey(hab.accountId, hab.assetId);
+                balanceAccounts.set(key, (balanceAccounts.get(key) || BigInt(0)) + hab.dBalance);
+                balanceHistory.push(hab);
+              })
+            );
             break;
           }
           case 'Tokens.Withdrawn': {


### PR DESCRIPTION
Fixes the below error: 

```
{
  "level": 5,
  "time": 1698810802164,
  "ns": "sqd:processor",
  "err": {
    "stack": "TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))\n    
    at Object.getTokensTransferEvent (/home/zeitgeist-squid/lib/mappings/tokens/types.js:104:40)\n    
    at Object.tokensTransfer (/home/zeitgeist-squid/lib/mappings/tokens/index.js:60:55)\n    
    at /home/zeitgeist-squid/lib/processor.js:585:52\n    
    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    
    at async TypeormDatabase.runTransaction (/home/zeitgeist-squid/node_modules/@subsquid/typeorm-store/lib/database.js:110:13)\n    
    at async TypeormDatabase.transact (/home/zeitgeist-squid/node_modules/@subsquid/typeorm-store/lib/database.js:64:24)\n    
    at async Runner.process (/home/zeitgeist-squid/node_modules/@subsquid/substrate-processor/lib/processor/runner.js:117:17)"
  }
}
```



