### PR TITLE
Set conditions for dispute-bond and disputes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -303,6 +303,8 @@ creating DAOs, and other parts of the protocol.
 type MarketBonds @jsonField {
   "Bond associated with creation of markets"
   creation: MarketBond!
+  "Bond reserved by the disputant"
+  dispute: MarketBond
   "Bond associated with oracle selection"
   oracle: MarketBond!
   "A bond for an outcome reporter, who is not the oracle"

--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -142,8 +142,6 @@ export const formatMarketEvent = (eventName: string): MarketEvent => {
       return MarketEvent.MarketCreated;
     case 'PredictionMarkets.MarketDestroyed':
       return MarketEvent.MarketDestroyed;
-    case 'PredictionMarkets.MarketDisputed':
-      return MarketEvent.MarketDisputed;
     case 'PredictionMarkets.MarketExpired':
       return MarketEvent.MarketExpired;
     case 'PredictionMarkets.MarketRejected':

--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -612,6 +612,7 @@ export const marketResolved = async (ctx: Ctx, block: SubstrateBlock, item: Even
   market.status = status ? formatMarketStatus(status) : MarketStatus.Resolved;
   if (market.bonds) {
     if (market.creation === MarketCreation.Permissionless) market.bonds.creation.isSettled = true;
+    if (market.bonds.dispute) market.bonds.dispute.isSettled = true;
     market.bonds.oracle.isSettled = true;
     if (market.bonds.outsider) market.bonds.outsider.isSettled = true;
   }

--- a/src/mappings/predictionMarkets/index.ts
+++ b/src/mappings/predictionMarkets/index.ts
@@ -436,10 +436,9 @@ export const marketDisputed = async (ctx: Ctx, block: SubstrateBlock, item: Even
   const market = await ctx.store.get(Market, { where: { marketId: +marketId.toString() } });
   if (!market) return;
 
-  let mr = new MarketReport();
-  if (specVersion(block.specId) >= 49) {
+  if (specVersion(block.specId) >= 42 && market.bonds) {
     const onChainBonds = await getMarketsStorage(ctx, block, BigInt(marketId));
-    if (onChainBonds && onChainBonds.dispute && market.bonds) {
+    if (onChainBonds && onChainBonds.dispute) {
       const bond = new MarketBond({
         isSettled: onChainBonds.dispute.isSettled,
         value: onChainBonds.dispute.value,
@@ -447,7 +446,11 @@ export const marketDisputed = async (ctx: Ctx, block: SubstrateBlock, item: Even
       });
       market.bonds.dispute = bond;
     }
-  } else {
+  }
+
+  let mr = new MarketReport();
+  // Conditions set based on PredictionMarketsDisputesStorage
+  if (specVersion(block.specId) < 49) {
     if (!market.disputes) market.disputes = [];
     mr = new MarketReport({
       at: block.height,

--- a/src/model/generated/_marketBonds.ts
+++ b/src/model/generated/_marketBonds.ts
@@ -9,6 +9,7 @@ import {MarketBond} from "./_marketBond"
  */
 export class MarketBonds {
     private _creation!: MarketBond
+    private _dispute!: MarketBond | undefined | null
     private _oracle!: MarketBond
     private _outsider!: MarketBond | undefined | null
 
@@ -16,6 +17,7 @@ export class MarketBonds {
         Object.assign(this, props)
         if (json != null) {
             this._creation = new MarketBond(undefined, marshal.nonNull(json.creation))
+            this._dispute = json.dispute == null ? undefined : new MarketBond(undefined, json.dispute)
             this._oracle = new MarketBond(undefined, marshal.nonNull(json.oracle))
             this._outsider = json.outsider == null ? undefined : new MarketBond(undefined, json.outsider)
         }
@@ -31,6 +33,17 @@ export class MarketBonds {
 
     set creation(value: MarketBond) {
         this._creation = value
+    }
+
+    /**
+     * Bond reserved by the disputant
+     */
+    get dispute(): MarketBond | undefined | null {
+        return this._dispute
+    }
+
+    set dispute(value: MarketBond | undefined | null) {
+        this._dispute = value
     }
 
     /**
@@ -59,6 +72,7 @@ export class MarketBonds {
     toJSON(): object {
         return {
             creation: this.creation.toJSON(),
+            dispute: this.dispute == null ? undefined : this.dispute.toJSON(),
             oracle: this.oracle.toJSON(),
             outsider: this.outsider == null ? undefined : this.outsider.toJSON(),
         }


### PR DESCRIPTION
As noticed on chain storage,
- Post `specVersion:42`, dispute bond will be available in `market.bonds`. Closes #449
- Post `specVersion:49`, dispute information will not be available in `market.disputes`. Freezes #302