### PR TITLE
Remove swap assets before attaching neo-swap assets

### DIFF
--- a/src/mappings/neo-swaps/index.ts
+++ b/src/mappings/neo-swaps/index.ts
@@ -352,6 +352,8 @@ export const poolDeployed = async (
   });
   if (!market) return;
 
+  // Check if market has swap pool and their assets attached to it
+  // Applicable for markets which have been migrated to neo-swap pool
   if (market.assets.length !== 0) {
     await Promise.all(
       market.assets.map(async (asset) => {
@@ -363,6 +365,7 @@ export const poolDeployed = async (
   const oldLiquidity = market.liquidity;
   let newLiquidity = BigInt(0);
   const historicalAssets: HistoricalAsset[] = [];
+
   await Promise.all(
     neoPool.account.balances.map(async (ab, i) => {
       if (isBaseAsset(ab.assetId)) return;

--- a/src/mappings/neo-swaps/index.ts
+++ b/src/mappings/neo-swaps/index.ts
@@ -348,6 +348,7 @@ export const poolDeployed = async (
 
   const market = await store.get(Market, {
     where: { marketId },
+    relations: { assets: true },
   });
   if (!market) return;
 

--- a/src/mappings/neo-swaps/index.ts
+++ b/src/mappings/neo-swaps/index.ts
@@ -351,6 +351,14 @@ export const poolDeployed = async (
   });
   if (!market) return;
 
+  if (market.assets.length !== 0) {
+    await Promise.all(
+      market.assets.map(async (asset) => {
+        console.log(`[${event.name}] Removing asset: ${JSON.stringify(asset, null, 2)}`);
+        await store.remove<Asset>(asset);
+      })
+    );
+  }
   const oldLiquidity = market.liquidity;
   let newLiquidity = BigInt(0);
   const historicalAssets: HistoricalAsset[] = [];


### PR DESCRIPTION
Post deployment of `specVersion:53` and storage migration of some markets from `AMM` to `Lmsr` pool, this PR removes the redundant assets arising out of multiple pools attached to the same market.

An example, `marketId:287` having redundant assets:

<img width="867" alt="Screenshot 2024-02-02 at 3 37 19 PM" src="https://github.com/zeitgeistpm/zeitgeist-subsquid/assets/36529278/90d9c686-88c2-44fa-8748-64c69275d077">
