### PR TITLE
Debug initialisation of OutcomeReport

### DIFF
--- a/src/mappings/authorized/index.ts
+++ b/src/mappings/authorized/index.ts
@@ -10,8 +10,8 @@ export const authorityReported = async (store: Store, event: Event) => {
   if (!market) return;
 
   const ocr = new OutcomeReport({
-    categorical: outcome.__kind == 'Categorical' ? outcome.value : null,
-    scalar: outcome.__kind == 'Scalar' ? outcome.value : null,
+    categorical: outcome.__kind === 'Categorical' ? outcome.value : undefined,
+    scalar: outcome.__kind === 'Scalar' ? outcome.value : undefined,
   });
   const mr = new MarketReport({
     at: event.block.height,

--- a/src/mappings/prediction-markets/index.ts
+++ b/src/mappings/prediction-markets/index.ts
@@ -642,8 +642,8 @@ export const marketReported = async (store: Store, event: Event) => {
   if (!market) return;
 
   const outcomeReport = new OutcomeReport({
-    categorical: outcome.__kind == 'Categorical' ? outcome.value : null,
-    scalar: outcome.__kind == 'Scalar' ? outcome.value : null,
+    categorical: outcome.__kind === 'Categorical' ? outcome.value : undefined,
+    scalar: outcome.__kind === 'Scalar' ? outcome.value : undefined,
   });
 
   const marketReport = new MarketReport({

--- a/src/mappings/prediction-markets/index.ts
+++ b/src/mappings/prediction-markets/index.ts
@@ -483,8 +483,8 @@ export const marketDisputed = async (store: Store, event: Event) => {
       by: accountId,
       outcome: outcome
         ? new OutcomeReport({
-            categorical: outcome.__kind == 'Categorical' ? outcome.value : null,
-            scalar: outcome.__kind == 'Scalar' ? outcome.value : null,
+            categorical: outcome.__kind === 'Categorical' ? outcome.value : undefined,
+            scalar: outcome.__kind === 'Scalar' ? outcome.value : undefined,
           })
         : null,
     });


### PR DESCRIPTION
Setting fields on `OutcomeReport` as `null` got compiled and saved on db without error. But failed while fetching records from postgres (db) posing as runtime error hidden within markets query. Fixes #513