### PR TITLE
Hook genesis balances

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -187,40 +187,6 @@ export const getFees = async (block: Block, extrinsic: _Extrinsic): Promise<bigi
   return totalFees;
 };
 
-export const initBalance = async (acc: Account, store: Store) => {
-  const event = {
-    id: '0000000000-000000-b3cc3',
-    name: 'Balances.Initialised',
-    timestamp: '1970-01-01T00:00:00.000Z',
-  };
-  const sdk = await Tools.getSDK();
-  const blockZero = await sdk.api.rpc.chain.getBlockHash(0);
-  const {
-    data: { free: amt },
-  } = (await sdk.api.query.system.account.at(blockZero, acc.accountId)) as AccountInfo;
-
-  const ab = new AccountBalance({
-    account: acc,
-    assetId: _Asset.Ztg,
-    balance: amt.toBigInt(),
-    id: event.id + '-' + acc.accountId.slice(-5),
-  });
-  console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`);
-  await store.save<AccountBalance>(ab);
-
-  const hab = new HistoricalAccountBalance({
-    accountId: acc.accountId,
-    assetId: _Asset.Ztg,
-    blockNumber: 0,
-    dBalance: amt.toBigInt(),
-    event: event.name.split('.')[1],
-    id: event.id + '-' + acc.accountId.slice(-5),
-    timestamp: new Date(event.timestamp),
-  });
-  console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`);
-  await store.save<HistoricalAccountBalance>(hab);
-};
-
 export const isBaseAsset = (assetId: Asset | string): boolean => {
   if (typeof assetId === 'string') {
     return assetId.includes('Ztg') || assetId.includes('foreignAsset');

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import {
 import * as postHooks from './post-hooks';
 import { calls, events } from './types';
 import { Pallet } from './consts';
-import { initBalance, isBatteryStation, isEventOrderValid, isMainnet } from './helper';
+import { isBatteryStation, isEventOrderValid, isMainnet } from './helper';
 import { processor, Event } from './processor';
 
 const accounts = new Map<string, Map<string, bigint>>();
@@ -93,7 +93,10 @@ processor.run(new TypeormDatabase(), async (ctx) => {
 });
 
 const handleBsrPostHooks = async (store: Store, blockHeight: number) => {
-  if (blockHeight >= 35683 && blockHeight <= 211391) {
+  if (blockHeight === 0) {
+    const historicalAccountBalances = await postHooks.initBalance();
+    await storeBalanceChanges(historicalAccountBalances);
+  } else if (blockHeight >= 35683 && blockHeight <= 211391) {
     await saveAccounts(store);
     const historicalAccountBalances = await postHooks.unreserveBalances(blockHeight);
     await storeBalanceChanges(historicalAccountBalances);

--- a/src/main.ts
+++ b/src/main.ts
@@ -549,7 +549,6 @@ const saveAccounts = async (store: Store) => {
         });
         console.log(`Saving account: ${JSON.stringify(account, null, 2)}`);
         await store.save<Account>(account);
-        await initBalance(account, store);
       }
 
       await Promise.all(

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,7 +108,10 @@ const handleBsrPostHooks = async (store: Store, blockHeight: number) => {
 };
 
 const handleMainPostHooks = async (store: Store, blockHeight: number) => {
-  if (blockHeight === 4793019) {
+  if (blockHeight === 0) {
+    const historicalAccountBalances = await postHooks.initBalance();
+    await storeBalanceChanges(historicalAccountBalances);
+  } else if (blockHeight === 4793019) {
     await postHooks.migrateScoringRule(store);
   }
 };

--- a/src/mappings/balances/index.ts
+++ b/src/mappings/balances/index.ts
@@ -1,7 +1,7 @@
 import { Store } from '@subsquid/typeorm-store';
 import { Account, AccountBalance, HistoricalAccountBalance } from '../../model';
 import { _Asset } from '../../consts';
-import { extrinsicFromEvent, initBalance } from '../../helper';
+import { extrinsicFromEvent } from '../../helper';
 import { Event } from '../../processor';
 import {
   decodeBalanceSetEvent,
@@ -25,7 +25,6 @@ export const balanceSet = async (store: Store, event: Event) => {
     });
     console.log(`[${event.name}] Saving account: ${JSON.stringify(account, null, 2)}`);
     await store.save<Account>(account);
-    await initBalance(account, store);
   }
 
   const ab = await store.findOneBy(AccountBalance, {

--- a/src/post-hooks/balancesUnreserved.ts
+++ b/src/post-hooks/balancesUnreserved.ts
@@ -18,7 +18,7 @@ export const unreserveBalances = async (blockHeight: number): Promise<Historical
           dBalance: ub.amount,
           event: 'Unreserved',
           id: ub.eventId + '-' + ub.accountId.slice(-5),
-          timestamp: new Date(ub.blockTimestamp),
+          timestamp: new Date(ub.blockTimestamp!),
         });
         habs.push(hab);
       })

--- a/src/post-hooks/balancesUnreserved.ts
+++ b/src/post-hooks/balancesUnreserved.ts
@@ -1,6 +1,6 @@
 import { HistoricalAccountBalance } from '../model';
 import { _Asset } from '../consts';
-import { UnreservedBalance } from '.';
+import { PostHookBalance } from '.';
 
 export const unreserveBalances = async (blockHeight: number): Promise<HistoricalAccountBalance[]> => {
   const habs: HistoricalAccountBalance[] = [];
@@ -10,7 +10,7 @@ export const unreserveBalances = async (blockHeight: number): Promise<Historical
       .filter((ub) => {
         return ub.blockHeight === blockHeight;
       })
-      .map(async (ub: UnreservedBalance) => {
+      .map(async (ub: PostHookBalance) => {
         const hab = new HistoricalAccountBalance({
           accountId: ub.accountId,
           assetId: _Asset.Ztg,
@@ -26,7 +26,7 @@ export const unreserveBalances = async (blockHeight: number): Promise<Historical
   return habs;
 };
 
-const unreservedBalances: UnreservedBalance[] = [
+const unreservedBalances: PostHookBalance[] = [
   {
     accountId: 'dDzCbtpYLKGKgV3xmuAbQdGNs6puwev2ZpbVP1L5VYSd2uF1Y',
     amount: BigInt(5 * 10 ** 10),

--- a/src/post-hooks/index.ts
+++ b/src/post-hooks/index.ts
@@ -13,7 +13,7 @@ export interface ResolvedMarket {
   resolvedOutcome: string;
 }
 
-export interface UnreservedBalance {
+export interface PostHookBalance {
   accountId: string;
   amount: bigint;
   blockHeight: number;

--- a/src/post-hooks/index.ts
+++ b/src/post-hooks/index.ts
@@ -1,9 +1,10 @@
 import { unreserveBalances } from './balancesUnreserved';
+import { initBalance } from './initBalance';
 import { destroyMarkets } from './marketDestroyed';
 import { resolveMarkets } from './marketResolved';
 import { migrateScoringRule } from './migrateScoringRule';
 
-export { destroyMarkets, migrateScoringRule, resolveMarkets, unreserveBalances };
+export { destroyMarkets, initBalance, migrateScoringRule, resolveMarkets, unreserveBalances };
 
 export interface ResolvedMarket {
   blockHeight: number;

--- a/src/post-hooks/index.ts
+++ b/src/post-hooks/index.ts
@@ -17,7 +17,7 @@ export interface ResolvedMarket {
 export interface PostHookBalance {
   accountId: string;
   amount: bigint;
-  blockHeight: number;
-  blockTimestamp: string;
-  eventId: string;
+  blockHeight?: number;
+  blockTimestamp?: string;
+  eventId?: string;
 }

--- a/src/post-hooks/initBalance.ts
+++ b/src/post-hooks/initBalance.ts
@@ -10,23 +10,23 @@ export const initBalance = async (): Promise<HistoricalAccountBalance[]> => {
     timestamp: '1970-01-01T00:00:00.000Z',
   };
 
-  let initialBalances: PostHookBalance[] = [];
+  let genesisBalances: PostHookBalance[] = [];
   if (isBatteryStation()) {
-    initialBalances = bsrInitialBalances;
+    genesisBalances = bsrGenesisBalances;
   } else if (isMainnet()) {
-    initialBalances = mainInitialBalances;
+    genesisBalances = mainGenesisBalances;
   }
 
   const habs: HistoricalAccountBalance[] = [];
   await Promise.all(
-    initialBalances.map(async (ib: PostHookBalance) => {
+    genesisBalances.map(async (gb: PostHookBalance) => {
       const hab = new HistoricalAccountBalance({
-        accountId: ib.accountId,
+        accountId: gb.accountId,
         assetId: _Asset.Ztg,
         blockNumber: 0,
-        dBalance: ib.amount,
+        dBalance: gb.amount,
         event: event.name.split('.')[1],
-        id: event.id + '-' + ib.accountId.slice(-5),
+        id: event.id + '-' + gb.accountId.slice(-5),
         timestamp: new Date(event.timestamp),
       });
       habs.push(hab);
@@ -35,7 +35,7 @@ export const initBalance = async (): Promise<HistoricalAccountBalance[]> => {
   return habs;
 };
 
-const bsrInitialBalances: PostHookBalance[] = [
+const bsrGenesisBalances: PostHookBalance[] = [
   {
     accountId: 'dE1VdxVn8xy7HFQG5y5px7T2W1TDpRq1QXHH2ozfZLhBMYiBJ',
     amount: BigInt(10 ** 8),
@@ -54,7 +54,7 @@ const bsrInitialBalances: PostHookBalance[] = [
   },
 ];
 
-const mainInitialBalances: PostHookBalance[] = [
+const mainGenesisBalances: PostHookBalance[] = [
   {
     accountId: 'dDykRtA8VyuVVtWTD5PWst3f33L1NMVKseQEji8e3B4ZCHrjK',
     amount: BigInt(100 * 10 ** 10),

--- a/src/post-hooks/initBalance.ts
+++ b/src/post-hooks/initBalance.ts
@@ -1,20 +1,33 @@
 import { HistoricalAccountBalance } from '../model';
 import { _Asset } from '../consts';
+import { isBatteryStation, isMainnet } from '../helper';
 import { PostHookBalance } from '.';
 
 export const initBalance = async (): Promise<HistoricalAccountBalance[]> => {
-  const habs: HistoricalAccountBalance[] = [];
+  const event = {
+    id: '0000000000-000000-b3cc3',
+    name: 'Balances.Initialised',
+    timestamp: '1970-01-01T00:00:00.000Z',
+  };
 
+  let initialBalances: PostHookBalance[] = [];
+  if (isBatteryStation()) {
+    initialBalances = bsrInitialBalances;
+  } else if (isMainnet()) {
+    initialBalances = mainInitialBalances;
+  }
+
+  const habs: HistoricalAccountBalance[] = [];
   await Promise.all(
     initialBalances.map(async (ib: PostHookBalance) => {
       const hab = new HistoricalAccountBalance({
         accountId: ib.accountId,
         assetId: _Asset.Ztg,
-        blockNumber: ib.blockHeight,
+        blockNumber: 0,
         dBalance: ib.amount,
-        event: 'Initialised',
-        id: ib.eventId + '-' + ib.accountId.slice(-5),
-        timestamp: new Date(ib.blockTimestamp),
+        event: event.name.split('.')[1],
+        id: event.id + '-' + ib.accountId.slice(-5),
+        timestamp: new Date(event.timestamp),
       });
       habs.push(hab);
     })
@@ -22,19 +35,32 @@ export const initBalance = async (): Promise<HistoricalAccountBalance[]> => {
   return habs;
 };
 
-const initialBalances: PostHookBalance[] = [
+const bsrInitialBalances: PostHookBalance[] = [
+  {
+    accountId: 'dE1VdxVn8xy7HFQG5y5px7T2W1TDpRq1QXHH2ozfZLhBMYiBJ',
+    amount: BigInt(10 ** 8),
+  },
+  {
+    accountId: 'dDz7L2zdPVCJG3aEprm1XjMdRUyb8QWckB5nWcnrz7eCV6JEc',
+    amount: BigInt(7998 * 10 ** 10),
+  },
+  {
+    accountId: 'dDyymrYQMxP5ksYCLXQjv9oAYiQdJFE9Ampgv8cYxc4qXpTNH',
+    amount: BigInt(10000 * 10 ** 10),
+  },
+  {
+    accountId: 'dE1c6MMASgZEtA4dm9qZhE7CXKK3vtbPYw2r56XoYmvyYaNDp',
+    amount: BigInt(10000 * 10 ** 10),
+  },
+];
+
+const mainInitialBalances: PostHookBalance[] = [
   {
     accountId: 'dDykRtA8VyuVVtWTD5PWst3f33L1NMVKseQEji8e3B4ZCHrjK',
     amount: BigInt(100 * 10 ** 10),
-    blockHeight: 0,
-    blockTimestamp: '1970-01-01T00:00:00.000Z',
-    eventId: '0000000000-000000-b3cc3',
   },
   {
     accountId: 'dE1VdxVn8xy7HFQG5y5px7T2W1TDpRq1QXHH2ozfZLhBMYiBJ',
     amount: BigInt(10 ** 8),
-    blockHeight: 0,
-    blockTimestamp: '1970-01-01T00:00:00.000Z',
-    eventId: '0000000000-000000-b3cc3',
   },
 ];

--- a/src/post-hooks/initBalance.ts
+++ b/src/post-hooks/initBalance.ts
@@ -1,0 +1,40 @@
+import { HistoricalAccountBalance } from '../model';
+import { _Asset } from '../consts';
+import { PostHookBalance } from '.';
+
+export const initBalance = async (): Promise<HistoricalAccountBalance[]> => {
+  const habs: HistoricalAccountBalance[] = [];
+
+  await Promise.all(
+    initialBalances.map(async (ib: PostHookBalance) => {
+      const hab = new HistoricalAccountBalance({
+        accountId: ib.accountId,
+        assetId: _Asset.Ztg,
+        blockNumber: ib.blockHeight,
+        dBalance: ib.amount,
+        event: 'Initialised',
+        id: ib.eventId + '-' + ib.accountId.slice(-5),
+        timestamp: new Date(ib.blockTimestamp),
+      });
+      habs.push(hab);
+    })
+  );
+  return habs;
+};
+
+const initialBalances: PostHookBalance[] = [
+  {
+    accountId: 'dDykRtA8VyuVVtWTD5PWst3f33L1NMVKseQEji8e3B4ZCHrjK',
+    amount: BigInt(100 * 10 ** 10),
+    blockHeight: 0,
+    blockTimestamp: '1970-01-01T00:00:00.000Z',
+    eventId: '0000000000-000000-b3cc3',
+  },
+  {
+    accountId: 'dE1VdxVn8xy7HFQG5y5px7T2W1TDpRq1QXHH2ozfZLhBMYiBJ',
+    amount: BigInt(10 ** 8),
+    blockHeight: 0,
+    blockTimestamp: '1970-01-01T00:00:00.000Z',
+    eventId: '0000000000-000000-b3cc3',
+  },
+];

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -7,7 +7,7 @@ import {
   Extrinsic as _Extrinsic,
 } from '@subsquid/substrate-processor';
 import { calls, events } from './types';
-import { isBatteryStation, isLocalEnv } from './helper';
+import { isBatteryStation, isLocalEnv, isMainnet } from './helper';
 
 (BigInt.prototype as any).toJSON = function () {
   return this.toString();
@@ -120,7 +120,12 @@ if (isBatteryStation()) {
       call: true,
       extrinsic: true,
     })
+    .includeAllBlocks({ from: 0, to: 0 })
     .includeAllBlocks({ from: 35683, to: 211391 });
+}
+
+if (isMainnet()) {
+  processor.includeAllBlocks({ from: 0, to: 0 });
 }
 
 if (!isLocalEnv()) {


### PR DESCRIPTION
This should eliminate calls to polkadot.js api for retrieving balance of all accounts at genesis block. Thus, should give little boost to the processor in terms of sync speed.