### PR TITLE
Unmap SystemNewAccountEvent

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -535,6 +535,7 @@ const mapTokens = async (store: Store, event: Event) => {
 };
 
 const saveAccounts = async (store: Store) => {
+  const accountBalances: AccountBalance[] = [];
   await Promise.all(
     Array.from(accounts).map(async ([accountId, balances]) => {
       let account = await store.get(Account, { where: { accountId } });
@@ -562,12 +563,15 @@ const saveAccounts = async (store: Store) => {
             });
           }
           ab.balance += amount;
-          console.log(`Saving account balance: ${JSON.stringify(ab, null, 2)}`);
-          await store.save<AccountBalance>(ab);
+          accountBalances.push(ab);
         })
       );
     })
   );
+  if (accountBalances.length > 0) {
+    console.log(`Saving account balances: ${JSON.stringify(accountBalances, null, 2)}`);
+    await store.save<AccountBalance>(accountBalances);
+  }
   accounts.clear();
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -501,10 +501,6 @@ const mapSystem = async (store: Store, event: Event) => {
       await storeBalanceChanges([hab]);
       break;
     }
-    case events.system.newAccount.name: {
-      await mappings.system.newAccount(store, event);
-      break;
-    }
   }
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ processor.run(new TypeormDatabase(), async (ctx) => {
           await mapSwaps(ctx.store, event);
           break;
         case Pallet.System:
-          await mapSystem(ctx.store, event);
+          await mapSystem(event);
           break;
         case Pallet.Tokens:
           await mapTokens(ctx.store, event);
@@ -489,7 +489,7 @@ const mapSwaps = async (store: Store, event: Event) => {
   }
 };
 
-const mapSystem = async (store: Store, event: Event) => {
+const mapSystem = async (event: Event) => {
   switch (event.name) {
     case events.system.extrinsicFailed.name: {
       const hab = await mappings.system.extrinsicFailed(event);

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ processor.run(new TypeormDatabase(), async (ctx) => {
           await mapPredictionMarkets(ctx.store, event);
           break;
         case Pallet.Styx:
-          await mapStyx(ctx.store, event);
+          await mapStyx(event);
           break;
         case Pallet.Swaps:
           await mapSwaps(ctx.store, event);
@@ -365,10 +365,11 @@ const mapPredictionMarkets = async (store: Store, event: Event) => {
   }
 };
 
-const mapStyx = async (store: Store, event: Event) => {
+const mapStyx = async (event: Event) => {
   switch (event.name) {
     case events.styx.accountCrossed.name:
-      await mappings.styx.accountCrossed(store, event);
+      const hab = await mappings.styx.accountCrossed(event);
+      await storeBalanceChanges([hab]);
       break;
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,7 +141,8 @@ const mapBalances = async (store: Store, event: Event) => {
   switch (event.name) {
     case events.balances.balanceSet.name: {
       await saveAccounts(store);
-      await mappings.balances.balanceSet(store, event);
+      const hab = await mappings.balances.balanceSet(store, event);
+      await storeBalanceChanges([hab]);
       break;
     }
     case events.balances.deposit.name: {

--- a/src/mappings/balances/index.ts
+++ b/src/mappings/balances/index.ts
@@ -1,5 +1,5 @@
 import { Store } from '@subsquid/typeorm-store';
-import { Account, AccountBalance, HistoricalAccountBalance } from '../../model';
+import { AccountBalance, HistoricalAccountBalance } from '../../model';
 import { _Asset } from '../../consts';
 import { extrinsicFromEvent } from '../../helper';
 import { Event } from '../../processor';
@@ -14,41 +14,25 @@ import {
   decodeWithdrawEvent,
 } from './decode';
 
-export const balanceSet = async (store: Store, event: Event) => {
+export const balanceSet = async (store: Store, event: Event): Promise<HistoricalAccountBalance> => {
   const { accountId, amount } = decodeBalanceSetEvent(event);
-
-  let account = await store.get(Account, { where: { accountId } });
-  if (!account) {
-    account = new Account({
-      accountId,
-      id: accountId,
-    });
-    console.log(`[${event.name}] Saving account: ${JSON.stringify(account, null, 2)}`);
-    await store.save<Account>(account);
-  }
 
   const ab = await store.findOneBy(AccountBalance, {
     account: { accountId },
     assetId: _Asset.Ztg,
   });
-  if (!ab) return;
-  const oldBalance = ab.balance;
-  ab.balance = amount;
-  console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`);
-  await store.save<AccountBalance>(ab);
-
+  const oldBalance = ab ? ab.balance : BigInt(0);
   const hab = new HistoricalAccountBalance({
     accountId,
     assetId: _Asset.Ztg,
     blockNumber: event.block.height,
-    dBalance: ab.balance - oldBalance,
+    dBalance: amount - oldBalance,
     event: event.name.split('.')[1],
     extrinsic: extrinsicFromEvent(event),
     id: event.id + '-' + accountId.slice(-5),
     timestamp: new Date(event.block.timestamp!),
   });
-  console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`);
-  await store.save<HistoricalAccountBalance>(hab);
+  return hab;
 };
 
 export const deposit = async (event: Event): Promise<HistoricalAccountBalance> => {

--- a/src/mappings/balances/index.ts
+++ b/src/mappings/balances/index.ts
@@ -22,11 +22,13 @@ export const balanceSet = async (store: Store, event: Event): Promise<Historical
     assetId: _Asset.Ztg,
   });
   const oldBalance = ab ? ab.balance : BigInt(0);
+  const newBalance = amount;
+
   const hab = new HistoricalAccountBalance({
     accountId,
     assetId: _Asset.Ztg,
     blockNumber: event.block.height,
-    dBalance: amount - oldBalance,
+    dBalance: newBalance - oldBalance,
     event: event.name.split('.')[1],
     extrinsic: extrinsicFromEvent(event),
     id: event.id + '-' + accountId.slice(-5),

--- a/src/mappings/system/decode.ts
+++ b/src/mappings/system/decode.ts
@@ -1,50 +1,29 @@
-import * as ss58 from '@subsquid/ss58';
 import { events } from '../../types';
 import { DispatchInfo } from '../../types/v23';
 import { Event } from '../../processor';
 
-export const decodeExtrinsicFailedEvent = (event: Event): ExtrinsicEvent => {
+export const extrinsicFailed = (event: Event): DispatchInfo => {
   if (events.system.extrinsicFailed.v23.is(event)) {
     const [, dispatchInfo] = events.system.extrinsicFailed.v23.decode(event);
-    return { dispatchInfo };
+    return dispatchInfo;
   } else if (events.system.extrinsicFailed.v32.is(event)) {
     const [, dispatchInfo] = events.system.extrinsicFailed.v32.decode(event);
-    return { dispatchInfo };
+    return dispatchInfo;
   } else {
     const [, dispatchInfo] = event.args;
-    return { dispatchInfo };
+    return dispatchInfo;
   }
 };
 
-export const decodeExtrinsicSuccessEvent = (event: Event): ExtrinsicEvent => {
+export const extrinsicSuccess = (event: Event): DispatchInfo => {
   if (events.system.extrinsicSuccess.v23.is(event)) {
     const dispatchInfo = events.system.extrinsicSuccess.v23.decode(event);
-    return { dispatchInfo };
+    return dispatchInfo;
   } else if (events.system.extrinsicSuccess.v34.is(event)) {
     const { dispatchInfo } = events.system.extrinsicSuccess.v34.decode(event);
-    return { dispatchInfo };
+    return dispatchInfo;
   } else {
     const [dispatchInfo] = event.args;
-    return { dispatchInfo };
+    return dispatchInfo;
   }
 };
-
-export const decodeNewAccountEvent = (event: Event): AccountEvent => {
-  let decoded: string;
-  if (events.system.newAccount.v23.is(event)) {
-    decoded = events.system.newAccount.v23.decode(event);
-  } else if (events.system.newAccount.v34.is(event)) {
-    decoded = events.system.newAccount.v34.decode(event).account;
-  } else {
-    decoded = event.args.account;
-  }
-  return { accountId: ss58.encode({ prefix: 73, bytes: decoded }) };
-};
-
-interface AccountEvent {
-  accountId: string;
-}
-
-interface ExtrinsicEvent {
-  dispatchInfo: DispatchInfo;
-}

--- a/src/mappings/system/index.ts
+++ b/src/mappings/system/index.ts
@@ -1,17 +1,16 @@
-import { Store } from '@subsquid/typeorm-store';
 import * as ss58 from '@subsquid/ss58';
-import { Account, AccountBalance, HistoricalAccountBalance } from '../../model';
+import { HistoricalAccountBalance } from '../../model';
 import { Pallet, _Asset } from '../../consts';
 import { extrinsicFromEvent, getFees } from '../../helper';
 import { Event } from '../../processor';
-import { decodeExtrinsicFailedEvent, decodeExtrinsicSuccessEvent, decodeNewAccountEvent } from './decode';
+import * as decode from './decode';
 
 export const extrinsicFailed = async (event: Event): Promise<HistoricalAccountBalance | undefined> => {
   if (!event.extrinsic || !event.extrinsic.signature || !event.extrinsic.signature.address) return;
   const accountId = ss58.encode({ prefix: 73, bytes: (event.extrinsic.signature.address as any).value });
 
-  const { dispatchInfo } = decodeExtrinsicFailedEvent(event);
-  if (dispatchInfo.paysFee.__kind == 'No') return;
+  const dispatchInfo = decode.extrinsicFailed(event);
+  if (dispatchInfo.paysFee.__kind === 'No') return;
 
   const hab = new HistoricalAccountBalance({
     accountId,
@@ -36,7 +35,7 @@ export const extrinsicSuccess = async (event: Event): Promise<HistoricalAccountB
     return;
   const accountId = ss58.encode({ prefix: 73, bytes: (event.extrinsic.signature.address as any).value });
 
-  const { dispatchInfo } = decodeExtrinsicSuccessEvent(event);
+  const dispatchInfo = decode.extrinsicSuccess(event);
   if (dispatchInfo.paysFee.__kind === 'No') return;
 
   const hab = new HistoricalAccountBalance({
@@ -50,39 +49,4 @@ export const extrinsicSuccess = async (event: Event): Promise<HistoricalAccountB
     timestamp: new Date(event.block.timestamp!),
   });
   return hab;
-};
-
-export const newAccount = async (store: Store, event: Event) => {
-  const { accountId } = decodeNewAccountEvent(event);
-
-  const account = await store.get(Account, { where: { accountId } });
-  if (account) return;
-
-  const newAccount = new Account({
-    accountId,
-    id: accountId,
-  });
-  console.log(`[${event.name}] Saving account: ${JSON.stringify(newAccount, null, 2)}`);
-  await store.save<Account>(newAccount);
-
-  const ab = new AccountBalance({
-    account: newAccount,
-    assetId: _Asset.Ztg,
-    balance: BigInt(0),
-    id: event.id + '-' + accountId.slice(-5),
-  });
-  console.log(`[${event.name}] Saving account balance: ${JSON.stringify(ab, null, 2)}`);
-  await store.save<AccountBalance>(ab);
-
-  const hab = new HistoricalAccountBalance({
-    accountId,
-    assetId: _Asset.Ztg,
-    blockNumber: event.block.height,
-    dBalance: BigInt(0),
-    event: event.name.split('.')[1],
-    id: event.id + '-' + accountId.slice(-5),
-    timestamp: new Date(event.block.timestamp!),
-  });
-  console.log(`[${event.name}] Saving historical account balance: ${JSON.stringify(hab, null, 2)}`);
-  await store.save<HistoricalAccountBalance>(hab);
 };

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -68,7 +68,6 @@ export const processor = new SubstrateBatchProcessor()
       events.swaps.poolExitWithExactAssetAmount.name,
       events.swaps.poolJoin.name,
       events.swaps.poolJoinWithExactAssetAmount.name,
-      events.system.newAccount.name,
       events.tokens.balanceSet.name,
       events.tokens.deposited.name,
       events.tokens.reserved.name,

--- a/src/types/system/events.ts
+++ b/src/types/system/events.ts
@@ -112,23 +112,3 @@ export const extrinsicFailed =  {
         })
     ),
 }
-
-export const newAccount =  {
-    name: 'System.NewAccount',
-    /**
-     *  A new \[account\] was created.
-     */
-    v23: new EventType(
-        'System.NewAccount',
-        v23.AccountId
-    ),
-    /**
-     * A new account was created.
-     */
-    v34: new EventType(
-        'System.NewAccount',
-        sts.struct({
-            account: v34.AccountId32,
-        })
-    ),
-}

--- a/typegen.json
+++ b/typegen.json
@@ -81,7 +81,7 @@
       ]
     },
     "System": {
-      "events": ["ExtrinsicFailed", "ExtrinsicSuccess", "NewAccount"]
+      "events": ["ExtrinsicFailed", "ExtrinsicSuccess"]
     },
     "Tokens": {
       "events": ["BalanceSet", "Deposited", "Reserved", "Transfer", "Withdrawn"]


### PR DESCRIPTION
Post #517 and with this PR, accounts can be initialised asynchronously as and when first on-chain transaction is processed. Therefore, there's no need to forcefully initialise account based on event `System.NewAccount`.