### PR TITLE
Async save changes from market resolution

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -217,10 +217,6 @@ export const mergeByAssetId = (balances: any[], weights: any[]): AssetAmountInPo
     ...weights.find((w) => w['_assetId'].toString() == b['assetId'].toString() && w),
   }));
 
-export const rescale = (value: string): string => {
-  return (BigInt(value) * BigInt(10 ** 10)).toString();
-};
-
 interface AssetAmountInPoolAndWeight {
   assetId: string;
   balance: bigint;

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,8 +100,10 @@ const handleBsrPostHooks = async (store: Store, blockHeight: number) => {
     await saveAccounts(store);
     const historicalAccountBalances = await postHooks.unreserveBalances(blockHeight);
     await storeBalanceChanges(historicalAccountBalances);
-    const historicalAssets = await postHooks.resolveMarkets(store, blockHeight);
-    assetHistory.push(...historicalAssets);
+    const res = await postHooks.resolveMarkets(store, blockHeight);
+    await storeBalanceChanges(res.historicalAccountBalances);
+    assetHistory.push(...res.historicalAssets);
+    marketHistory.push(...res.historicalMarkets);
   } else if (blockHeight === 579750) {
     await saveAccounts(store);
     await postHooks.destroyMarkets(store);

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,7 +100,7 @@ const handleBsrPostHooks = async (store: Store, blockHeight: number) => {
     await saveAccounts(store);
     const historicalAccountBalances = await postHooks.unreserveBalances(blockHeight);
     await storeBalanceChanges(historicalAccountBalances);
-    const res = await postHooks.resolveMarkets(store, blockHeight);
+    const res = await postHooks.resolveMarket(store, blockHeight);
     await storeBalanceChanges(res.historicalAccountBalances);
     assetHistory.push(...res.historicalAssets);
     marketHistory.push(...res.historicalMarkets);

--- a/src/main.ts
+++ b/src/main.ts
@@ -344,7 +344,11 @@ const mapPredictionMarkets = async (store: Store, event: Event) => {
     }
     case events.predictionMarkets.marketResolved.name: {
       await saveAccounts(store);
-      await mappings.predictionMarkets.marketResolved(store, event);
+      const res = await mappings.predictionMarkets.marketResolved(store, event);
+      if (!res) break;
+      await storeBalanceChanges(res.historicalAccountBalances);
+      assetHistory.push(...res.historicalAssets);
+      marketHistory.push(res.historicalMarket);
       break;
     }
     case events.predictionMarkets.marketStartedWithSubsidy.name: {

--- a/src/mappings/prediction-markets/helper.ts
+++ b/src/mappings/prediction-markets/helper.ts
@@ -26,3 +26,7 @@ export const mapMarketPeriod = async (p: _MarketPeriod): Promise<MarketPeriod> =
   }
   return period;
 };
+
+export const scaleUp = (value: string): string => {
+  return (BigInt(value) * BigInt(10 ** 10)).toString();
+};

--- a/src/mappings/prediction-markets/index.ts
+++ b/src/mappings/prediction-markets/index.ts
@@ -31,7 +31,6 @@ import {
   formatDisputeMechanism,
   formatMarketStatus,
   formatScoringRule,
-  rescale,
 } from '../../helper';
 import { Call, Event } from '../../processor';
 import { decodeMarketsStorage } from '../market-commons/decode';
@@ -54,7 +53,7 @@ import {
   decodeSoldCompleteSetEvent,
   decodeTokensRedeemedEvent,
 } from './decode';
-import { mapMarketPeriod } from './helper';
+import { mapMarketPeriod, scaleUp } from './helper';
 
 export const boughtCompleteSet = async (
   store: Store,
@@ -323,12 +322,12 @@ export const marketCreated = async (store: Store, event: Event) => {
     marketType.scalar = [];
     if (event.block.specVersion < 41) {
       if (type.value.start) {
-        marketType.scalar.push(rescale(type.value.start.toString()));
-        marketType.scalar.push(rescale(type.value.end.toString()));
+        marketType.scalar.push(scaleUp(type.value.start.toString()));
+        marketType.scalar.push(scaleUp(type.value.end.toString()));
       } else {
         const [start, end] = type.value.toString().split(`,`);
-        marketType.scalar.push(rescale(start));
-        marketType.scalar.push(rescale(end));
+        marketType.scalar.push(scaleUp(start));
+        marketType.scalar.push(scaleUp(end));
       }
     } else {
       marketType.scalar.push(type.value.start.toString());
@@ -693,7 +692,7 @@ export const marketResolved = async (
 
   market.resolvedOutcome =
     market.marketType.scalar && event.block.specVersion < 41
-      ? rescale(report.value.toString())
+      ? scaleUp(report.value.toString())
       : report.value.toString();
   market.status = MarketStatus.Resolved;
   if (market.bonds) {

--- a/src/mappings/prediction-markets/index.ts
+++ b/src/mappings/prediction-markets/index.ts
@@ -1,7 +1,6 @@
 import { Store } from '@subsquid/typeorm-store';
 import * as ss58 from '@subsquid/ss58';
 import { util } from '@zeitgeistpm/sdk';
-import { Like } from 'typeorm';
 import {
   Account,
   AccountBalance,

--- a/src/post-hooks/index.ts
+++ b/src/post-hooks/index.ts
@@ -1,10 +1,10 @@
 import { unreserveBalances } from './balancesUnreserved';
 import { initBalance } from './initBalance';
 import { destroyMarkets } from './marketDestroyed';
-import { resolveMarkets } from './marketResolved';
 import { migrateScoringRule } from './migrateScoringRule';
+import { resolveMarket } from './resolveMarket';
 
-export { destroyMarkets, initBalance, migrateScoringRule, resolveMarkets, unreserveBalances };
+export { destroyMarkets, initBalance, migrateScoringRule, unreserveBalances, resolveMarket };
 
 export interface ResolvedMarket {
   blockHeight: number;

--- a/src/post-hooks/resolveMarket.ts
+++ b/src/post-hooks/resolveMarket.ts
@@ -11,7 +11,7 @@ import {
 } from '../model';
 import { ResolvedMarket } from '.';
 
-export const resolveMarkets = async (
+export const resolveMarket = async (
   store: Store,
   blockHeight: number
 ): Promise<{
@@ -19,7 +19,6 @@ export const resolveMarkets = async (
   historicalAssets: HistoricalAsset[];
   historicalMarkets: HistoricalMarket[];
 }> => {
-  const eventName = 'PostHooks.MarketResolved';
   const historicalAccountBalances: HistoricalAccountBalance[] = [];
   const historicalAssets: HistoricalAsset[] = [];
   const historicalMarkets: HistoricalMarket[] = [];
@@ -52,7 +51,7 @@ export const resolveMarkets = async (
                   assetId: ab.assetId,
                   blockNumber: rm.blockHeight,
                   dBalance: -ab.balance,
-                  event: eventName.split('.')[1],
+                  event: MarketEvent.MarketResolved,
                   id: rm.eventId + '-' + market.marketId + i + '-' + ab.account.accountId.slice(-5),
                   timestamp: new Date(rm.blockTimestamp),
                 });
@@ -83,7 +82,7 @@ export const resolveMarkets = async (
             }
             asset.price = newPrice;
             asset.amountInPool = newAssetQty;
-            console.log(`[${eventName}] Saving asset: ${JSON.stringify(asset, null, 2)}`);
+            console.log(`[PostHooks.MarketResolved] Saving asset: ${JSON.stringify(asset, null, 2)}`);
             await store.save<Asset>(asset);
 
             newLiquidity += BigInt(Math.round(asset.price * +asset.amountInPool.toString()));
@@ -94,7 +93,7 @@ export const resolveMarkets = async (
               blockNumber: rm.blockHeight,
               dAmountInPool: newAssetQty - oldAssetQty,
               dPrice: newPrice - oldPrice,
-              event: eventName.split('.')[1],
+              event: MarketEvent.MarketResolved,
               id: rm.eventId + '-' + asset.id.substring(asset.id.lastIndexOf('-') + 1),
               newAmountInPool: newAssetQty,
               newPrice: newPrice,
@@ -106,7 +105,7 @@ export const resolveMarkets = async (
 
         market.liquidity = newLiquidity;
         market.status = MarketStatus.Resolved;
-        console.log(`[${eventName}] Saving market: ${JSON.stringify(market, null, 2)}`);
+        console.log(`[PostHooks.MarketResolved] Saving market: ${JSON.stringify(market, null, 2)}`);
         await store.save<Market>(market);
 
         const hm = new HistoricalMarket({


### PR DESCRIPTION
As monitored via logs, a lot of transactions happen after market is resolved. Therefore, batching them would help ease synchronisation for processor.