### PR TITLE
Set price range between market-creation and resolution

### DIFF
--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -163,7 +163,7 @@ export const marketInfo = (marketId: number) => `
     historical_market hm ON hm.market_id = m.id
   WHERE
     m.market_id = ${marketId}
-    AND hm.event ~ '(Pool|Resolved)'
+    AND hm.event ~ '(Created|Resolved)'
   GROUP BY
     m.outcome_assets,
     hm.timestamp;


### PR DESCRIPTION
Prices for migrated pool markets seemed distorted on UI due to constraints being set based on timestamps of deployment of pool and market resolution. 

However, for all markets there would be one record for market-creation and another for market-resolved on `HistoricalMarket`. This PR utilises timestamp from these two records to set upper and lower limit while computing asset prices vs timestamp. Closes #516