### PR TITLE
Open AssetPriceResolver for app-docker

### DIFF
--- a/src/server-extension/helper.ts
+++ b/src/server-extension/helper.ts
@@ -20,6 +20,7 @@ export const fetchFromCache = async (b: string, t: string): Promise<{ pair: stri
   const target = Object.keys(TargetAsset)[Object.values(TargetAsset).indexOf(<any>t)];
   const pair = `${base}/${target}`;
 
+  if (isLocalEnv()) return { pair, price: 1 };
   const price = await (await Cache.init()).getData(CacheHint.Price, pair);
   return { pair, price: price ? +price : 1 };
 };
@@ -50,6 +51,7 @@ export const mergeByField = (array1: any[], array2: any[], field: string) =>
 
 // Fetch prices from Coingecko for all supported assets
 export const refreshPrices = async () => {
+  if (isLocalEnv()) return;
   const ids = Object.values(BaseAsset).join(',');
   const vs_currencies = Object.values(TargetAsset).join(',');
   let res;

--- a/src/server-extension/resolvers/assetPrice.ts
+++ b/src/server-extension/resolvers/assetPrice.ts
@@ -1,7 +1,6 @@
 import { Arg, Field, ObjectType, Query, Resolver } from 'type-graphql';
 import { EntityManager } from 'typeorm';
 import { BaseAsset, EPOCH_TIME, TargetAsset } from '../../consts';
-import { isLocalEnv } from '../../helper';
 import { fetchFromCache, refreshPrices } from '../helper';
 
 @ObjectType()
@@ -31,8 +30,6 @@ export class AssetPriceResolver {
     @Arg('base', () => [BaseAsset], { nullable: false }) base: BaseAsset[],
     @Arg('target', () => [TargetAsset], { nullable: false }) target: TargetAsset[]
   ): Promise<AssetPrice[] | undefined> {
-    if (isLocalEnv()) return;
-
     // Refresh prices if they are older than 60 minutes
     if (new Date().getTime() - AssetPriceResolver.cachedAt.getTime() > 60 * 60 * 1000) refreshPrices();
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,16 +6,18 @@ import { concat, toString } from 'uint8arrays';
 import CID from 'cids';
 import all from 'it-all';
 import { CacheHint } from './consts';
+import { isLocalEnv } from './helper';
 
 export class Cache {
   private static _instance: Cache;
   private client: RedisClient;
 
-  constructor(redisOptions: ClientOpts) {
+  constructor(redisOptions?: ClientOpts) {
     this.client = createClient(redisOptions);
   }
 
   public static async init() {
+    if (isLocalEnv()) this._instance = new Cache();
     if (!this._instance) {
       console.log('Connecting to Redis DB...');
       this._instance = new Cache({


### PR DESCRIPTION
UI has it embedded in their logic to fetch real-time prices of assets from Coingecko. But for development purposes, it would be fine to use default price (currently set as 1) without bothering the Subsquid logic (which fetches price from redis-db before hitting Coingecko). 

This PR allows UI to fetch default price for development purposes (via app-docker).