### PR TITLE
Reframe id on asset and save together on pool creation

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -77,10 +77,6 @@ export const decodeMarketMetadata = async (metadata: string): Promise<DecodedMar
   return cachedData && cachedData !== '0' ? JSON.parse(cachedData) : undefined;
 };
 
-const extractCategoricalOutcomeIndex = (s: string): number => {
-  return +s.substring(s.indexOf(',') + 1, s.indexOf(']'));
-};
-
 export const extrinsicFromEvent = (event: any): Extrinsic | null => {
   if (!event.extrinsic) return null;
   return new Extrinsic({
@@ -227,15 +223,4 @@ interface AssetAmountInPoolAndWeight {
 
 export const pad = (i: number): string => {
   return i < 10 ? '0' + i.toString() : i.toString();
-};
-
-export const sortOutcomeAssets = (data: Asset_[]): Asset_[] => {
-  if (data[0].assetId.includes('scalar')) {
-    return data.sort((a, b) => {
-      return a.assetId.localeCompare(b.assetId);
-    });
-  }
-  return data.sort((a, b) => {
-    return extractCategoricalOutcomeIndex(a.assetId) - extractCategoricalOutcomeIndex(b.assetId);
-  });
 };

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -225,6 +225,10 @@ interface AssetAmountInPoolAndWeight {
   _weight: bigint;
 }
 
+export const pad = (i: number): string => {
+  return i < 10 ? '0' + i.toString() : i.toString();
+};
+
 export const sortOutcomeAssets = (data: Asset_[]): Asset_[] => {
   if (data[0].assetId.includes('scalar')) {
     return data.sort((a, b) => {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -3,7 +3,7 @@ import { util } from '@zeitgeistpm/sdk';
 import Decimal from 'decimal.js';
 import axios from 'axios';
 import CID from 'cids';
-import { DisputeMechanism, Extrinsic, MarketStatus, ScoringRule } from './model';
+import { AccountBalance, Asset as Asset_, DisputeMechanism, Extrinsic, MarketStatus, ScoringRule } from './model';
 import {
   Asset,
   MarketDisputeMechanism as _DisputeMechanism,
@@ -75,6 +75,10 @@ export const decodeMarketMetadata = async (metadata: string): Promise<DecodedMar
   }
   // Parse raw data fetched from either IPFS or redis
   return cachedData && cachedData !== '0' ? JSON.parse(cachedData) : undefined;
+};
+
+const extractCategoricalOutcomeIndex = (s: string): number => {
+  return +s.substring(s.indexOf(',') + 1, s.indexOf(']'));
 };
 
 export const extrinsicFromEvent = (event: any): Extrinsic | null => {
@@ -220,3 +224,14 @@ interface AssetAmountInPoolAndWeight {
   balance: bigint;
   _weight: bigint;
 }
+
+export const sortOutcomeAssets = (data: Asset_[]): Asset_[] => {
+  if (data[0].assetId.includes('scalar')) {
+    return data.sort((a, b) => {
+      return a.assetId.localeCompare(b.assetId);
+    });
+  }
+  return data.sort((a, b) => {
+    return extractCategoricalOutcomeIndex(a.assetId) - extractCategoricalOutcomeIndex(b.assetId);
+  });
+};

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -3,7 +3,7 @@ import { util } from '@zeitgeistpm/sdk';
 import Decimal from 'decimal.js';
 import axios from 'axios';
 import CID from 'cids';
-import { AccountBalance, Asset as Asset_, DisputeMechanism, Extrinsic, MarketStatus, ScoringRule } from './model';
+import { DisputeMechanism, Extrinsic, MarketStatus, ScoringRule } from './model';
 import {
   Asset,
   MarketDisputeMechanism as _DisputeMechanism,

--- a/src/mappings/neo-swaps/index.ts
+++ b/src/mappings/neo-swaps/index.ts
@@ -11,7 +11,7 @@ import {
   NeoPool,
 } from '../../model';
 import { SwapEvent } from '../../consts';
-import { computeNeoSwapSpotPrice, extrinsicFromEvent, isBaseAsset, sortOutcomeAssets } from '../../helper';
+import { computeNeoSwapSpotPrice, extrinsicFromEvent, isBaseAsset, pad, sortOutcomeAssets } from '../../helper';
 import { Event } from '../../processor';
 import {
   decodeBuyExecutedEvent,
@@ -377,7 +377,7 @@ export const poolDeployed = async (
       const asset = new Asset({
         assetId: ab.assetId,
         amountInPool: ab.balance,
-        id: event.id + '-' + neoPool.marketId + i,
+        id: event.id + '-' + neoPool.marketId + pad(i),
         market,
         price: computeNeoSwapSpotPrice(ab.balance, neoPool.liquidityParameter),
       });

--- a/src/mappings/neo-swaps/index.ts
+++ b/src/mappings/neo-swaps/index.ts
@@ -11,7 +11,7 @@ import {
   NeoPool,
 } from '../../model';
 import { SwapEvent } from '../../consts';
-import { computeNeoSwapSpotPrice, extrinsicFromEvent, isBaseAsset, pad, sortOutcomeAssets } from '../../helper';
+import { computeNeoSwapSpotPrice, extrinsicFromEvent, isBaseAsset, pad } from '../../helper';
 import { Event } from '../../processor';
 import {
   decodeBuyExecutedEvent,
@@ -401,9 +401,8 @@ export const poolDeployed = async (
     })
   );
 
-  const orderedAssets = sortOutcomeAssets(assets);
-  console.log(`[${event.name}] Saving assets: ${JSON.stringify(orderedAssets, null, 2)}`);
-  await store.save<Asset>(orderedAssets);
+  console.log(`[${event.name}] Saving assets: ${JSON.stringify(assets, null, 2)}`);
+  await store.save<Asset>(assets);
 
   market.neoPool = neoPool;
   market.liquidity = newLiquidity;

--- a/src/mappings/neo-swaps/index.ts
+++ b/src/mappings/neo-swaps/index.ts
@@ -368,6 +368,7 @@ export const poolDeployed = async (
   }
   const oldLiquidity = market.liquidity;
   let newLiquidity = BigInt(0);
+  const assets: Asset[] = [];
   const historicalAssets: HistoricalAsset[] = [];
 
   await Promise.all(
@@ -380,9 +381,8 @@ export const poolDeployed = async (
         market,
         price: computeNeoSwapSpotPrice(ab.balance, neoPool.liquidityParameter),
       });
-      console.log(`[${event.name}] Saving asset: ${JSON.stringify(asset, null, 2)}`);
-      await store.save<Asset>(asset);
 
+      assets.push(asset);
       newLiquidity += BigInt(Math.round(asset.price * +ab.balance.toString()));
 
       const ha = new HistoricalAsset({
@@ -400,6 +400,9 @@ export const poolDeployed = async (
       historicalAssets.push(ha);
     })
   );
+
+  console.log(`[${event.name}] Saving assets: ${JSON.stringify(assets, null, 2)}`);
+  await store.save<Asset>(assets);
 
   market.neoPool = neoPool;
   market.liquidity = newLiquidity;

--- a/src/mappings/neo-swaps/index.ts
+++ b/src/mappings/neo-swaps/index.ts
@@ -11,7 +11,7 @@ import {
   NeoPool,
 } from '../../model';
 import { SwapEvent } from '../../consts';
-import { computeNeoSwapSpotPrice, extrinsicFromEvent, isBaseAsset } from '../../helper';
+import { computeNeoSwapSpotPrice, extrinsicFromEvent, isBaseAsset, sortOutcomeAssets } from '../../helper';
 import { Event } from '../../processor';
 import {
   decodeBuyExecutedEvent,
@@ -401,8 +401,9 @@ export const poolDeployed = async (
     })
   );
 
-  console.log(`[${event.name}] Saving assets: ${JSON.stringify(assets, null, 2)}`);
-  await store.save<Asset>(assets);
+  const orderedAssets = sortOutcomeAssets(assets);
+  console.log(`[${event.name}] Saving assets: ${JSON.stringify(orderedAssets, null, 2)}`);
+  await store.save<Asset>(orderedAssets);
 
   market.neoPool = neoPool;
   market.liquidity = newLiquidity;

--- a/src/mappings/swaps/index.ts
+++ b/src/mappings/swaps/index.ts
@@ -18,7 +18,14 @@ import {
   Weight,
 } from '../../model';
 import { Pallet, SWAP_EXACT_AMOUNT_IN, SWAP_EXACT_AMOUNT_OUT, SwapEvent } from '../../consts';
-import { computeSwapSpotPrice, extrinsicFromEvent, formatAssetId, isBaseAsset, mergeByAssetId } from '../../helper';
+import {
+  computeSwapSpotPrice,
+  extrinsicFromEvent,
+  formatAssetId,
+  isBaseAsset,
+  mergeByAssetId,
+  sortOutcomeAssets,
+} from '../../helper';
 import { Call, Event } from '../../processor';
 import { Tools } from '../../util';
 import {
@@ -396,8 +403,9 @@ export const poolCreate = async (
     timestamp: new Date(event.block.timestamp!),
   });
 
-  console.log(`[${event.name}] Saving assets: ${JSON.stringify(assets, null, 2)}`);
-  await store.save<Asset>(assets);
+  const orderedAssets = sortOutcomeAssets(assets);
+  console.log(`[${event.name}] Saving assets: ${JSON.stringify(orderedAssets, null, 2)}`);
+  await store.save<Asset>(orderedAssets);
 
   market.liquidity = newLiquidity;
   console.log(`[${event.name}] Saving market: ${JSON.stringify(market, null, 2)}`);

--- a/src/mappings/swaps/index.ts
+++ b/src/mappings/swaps/index.ts
@@ -24,6 +24,7 @@ import {
   formatAssetId,
   isBaseAsset,
   mergeByAssetId,
+  pad,
   sortOutcomeAssets,
 } from '../../helper';
 import { Call, Event } from '../../processor';
@@ -366,7 +367,7 @@ export const poolCreate = async (
         const asset = new Asset({
           assetId: wt.assetId,
           amountInPool: BigInt(assetQty),
-          id: event.id + '-' + pool.marketId + i,
+          id: event.id + '-' + pool.marketId + pad(i),
           market,
           pool: newPool,
           price: computeSwapSpotPrice(+baseAssetQty.toString(), baseAssetWeight, assetQty, +wt.weight.toString()),

--- a/src/mappings/swaps/index.ts
+++ b/src/mappings/swaps/index.ts
@@ -25,7 +25,6 @@ import {
   isBaseAsset,
   mergeByAssetId,
   pad,
-  sortOutcomeAssets,
 } from '../../helper';
 import { Call, Event } from '../../processor';
 import { Tools } from '../../util';
@@ -404,9 +403,8 @@ export const poolCreate = async (
     timestamp: new Date(event.block.timestamp!),
   });
 
-  const orderedAssets = sortOutcomeAssets(assets);
-  console.log(`[${event.name}] Saving assets: ${JSON.stringify(orderedAssets, null, 2)}`);
-  await store.save<Asset>(orderedAssets);
+  console.log(`[${event.name}] Saving assets: ${JSON.stringify(assets, null, 2)}`);
+  await store.save<Asset>(assets);
 
   market.liquidity = newLiquidity;
   console.log(`[${event.name}] Saving market: ${JSON.stringify(market, null, 2)}`);


### PR DESCRIPTION
This should help ordering of assets connected to market by `id_ASC` in allegiance with on-chain order. Closes #536 