### PR TITLE
Fix balanceInfo resolver

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -96,6 +96,8 @@ export const formatAssetId = (assetId: Asset_v51 | Asset_v54): string => {
     case _Asset.CampaignAsset:
       return JSON.stringify({ campaignAsset: Number(assetId.value) });
     case _Asset.CategoricalOutcome:
+      if (typeof assetId.value === 'string')
+        return JSON.stringify({ categoricalOutcome: (assetId.value as any as string).split(',').map(Number) });
       return JSON.stringify({ categoricalOutcome: assetId.value.map(Number) });
     case _Asset.CustomAsset:
       return JSON.stringify({ customAsset: Number(assetId.value) });


### PR DESCRIPTION
Adapts `formatAssetId` to include parameters from `balanceInfo` resolver

Fixes:
<img width="1031" alt="Screenshot 2024-05-06 at 10 46 16 AM" src="https://github.com/zeitgeistpm/zeitgeist-subsquid/assets/36529278/67e7ad29-fae0-46c4-b6c4-9f36bf6763fd">
