### PR TITLE
Query court storage `marketIdToCourtId`

### DIFF
--- a/src/mappings/court/decode.ts
+++ b/src/mappings/court/decode.ts
@@ -1,8 +1,8 @@
 import * as ss58 from '@subsquid/ss58';
 import { CourtInfo } from '../../types/v51';
-import { events } from '../../types';
+import { events, storage } from '../../types';
 import { _Asset } from '../../consts';
-import { Event } from '../../processor';
+import { Block, Event } from '../../processor';
 
 export const courtOpened = (event: Event): CourtOpenedEvent => {
   let decoded: {
@@ -34,6 +34,14 @@ export const jurorVoted = (event: Event): CourtEvent => {
     courtId: +decoded.courtId.toString(),
     accountId: ss58.encode({ prefix: 73, bytes: decoded.juror }),
   };
+};
+
+export const marketIdToCourtId = async (block: Block, marketId: number): Promise<string | undefined> => {
+  let courtId: bigint | undefined;
+  if (storage.court.marketIdToCourtId.v49.is(block)) {
+    courtId = await storage.court.marketIdToCourtId.v49.get(block, BigInt(marketId));
+  }
+  return courtId?.toString();
 };
 
 interface CourtEvent {

--- a/src/mappings/court/index.ts
+++ b/src/mappings/court/index.ts
@@ -7,7 +7,7 @@ export const courtOpened = async (event: Event): Promise<{ court: Court; histori
   const { marketId, courtInfo } = decode.courtOpened(event);
 
   const court = new Court({
-    id: marketId.toString(),
+    id: (await decode.marketIdToCourtId(event.block, marketId)) ?? marketId.toString(),
     marketId,
     roundEnds: new RoundEndsInfo({
       preVote: courtInfo.roundEnds.preVote,

--- a/src/types/court/storage.ts
+++ b/src/types/court/storage.ts
@@ -1,0 +1,25 @@
+import {sts, Block, Bytes, Option, Result, StorageType, RuntimeCtx} from '../support'
+
+export const marketIdToCourtId =  {
+    /**
+     *  Mapping from market id to court id.
+     */
+    v49: new StorageType('Court.MarketIdToCourtId', 'Optional', [sts.bigint()], sts.bigint()) as MarketIdToCourtIdV49,
+}
+
+/**
+ *  Mapping from market id to court id.
+ */
+export interface MarketIdToCourtIdV49  {
+    is(block: RuntimeCtx): boolean
+    get(block: Block, key: bigint): Promise<(bigint | undefined)>
+    getMany(block: Block, keys: bigint[]): Promise<(bigint | undefined)[]>
+    getKeys(block: Block): Promise<bigint[]>
+    getKeys(block: Block, key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number, block: Block): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, block: Block, key: bigint): AsyncIterable<bigint[]>
+    getPairs(block: Block): Promise<[k: bigint, v: (bigint | undefined)][]>
+    getPairs(block: Block, key: bigint): Promise<[k: bigint, v: (bigint | undefined)][]>
+    getPairsPaged(pageSize: number, block: Block): AsyncIterable<[k: bigint, v: (bigint | undefined)][]>
+    getPairsPaged(pageSize: number, block: Block, key: bigint): AsyncIterable<[k: bigint, v: (bigint | undefined)][]>
+}

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,2 +1,3 @@
 export * as marketCommons from './market-commons/storage'
 export * as assetRegistry from './asset-registry/storage'
+export * as court from './court/storage'

--- a/typegen.json
+++ b/typegen.json
@@ -27,7 +27,8 @@
       "events": ["Burned", "Issued", "Transferred"]
     },
     "Court": {
-      "events": ["CourtOpened", "JurorVoted", "MintedInCourt"]
+      "events": ["CourtOpened", "JurorVoted", "MintedInCourt"],
+      "storage": ["MarketIdToCourtId"]
     },
     "Currency": {
       "events": ["Deposited", "Transferred", "Withdrawn"]


### PR DESCRIPTION
As courtId is absent on `Court.CourtOpened` event, it would be necessary to query the same on-chain while initialising court object