### PR TITLE
Ensure totalLiquidityAndVolume works when the old pool is missing on market

### DIFF
--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -218,31 +218,54 @@ export const marketVolume = (ids: number[], prices: Map<BaseAsset, number>) => `
 `;
 
 export const totalLiquidityAndVolume = () => `
-  SELECT
-    ROUND(SUM(liquidity),0) AS total_liquidity,
-    SUM(volume) AS total_volume
-  FROM (
+  WITH pool_stats AS (
     SELECT
       m.market_id,
-      SUM(a.price*a.amount_in_pool)+ab.balance AS liquidity,
-      COALESCE(p.volume, m.volume) as volume
+      SUM(a.price * a.amount_in_pool) + ab.balance AS liquidity,
+      p.volume
     FROM
       market m
     JOIN
       asset a ON a.asset_id = ANY (m.outcome_assets)
-    LEFT JOIN
+    JOIN
       pool p ON p.id = m.pool_id
     JOIN
-      account_balance ab ON ab.account_id = COALESCE(p.account_id, m.account_id)
+      account_balance ab ON ab.account_id = p.account_id
     WHERE
       ab.asset_id NOT LIKE '%Outcome%'
       AND ab.balance > 0
     GROUP BY
       m.market_id,
       ab.balance,
-      p.volume,
+      p.volume
+  ),
+  neo_pool_stats AS (
+    SELECT
+      m.market_id,
+      SUM(a.price * ab.balance) AS liquidity,
       m.volume
-  ) AS market_stats;
+    FROM
+      market m
+    JOIN
+      asset a ON a.asset_id = ANY (m.outcome_assets)
+    JOIN
+      neo_pool np ON np.id = m.neo_pool_id
+    JOIN
+      account_balance ab ON ab.account_id = np.account_id
+    WHERE
+      ab.asset_id LIKE '%Outcome%'
+    GROUP BY
+      m.market_id,
+      m.volume
+  )
+  SELECT
+    ROUND(SUM(liquidity), 0) AS total_liquidity,
+    SUM(volume) AS total_volume
+  FROM (
+    SELECT * FROM pool_stats
+    UNION ALL
+    SELECT * FROM neo_pool_stats
+  ) AS combined_stats;
 `;
 
 export const totalMintedInCourt = () => `

--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -225,13 +225,7 @@ export const totalLiquidityAndVolume = () => `
     SELECT
       m.market_id,
       SUM(a.price*a.amount_in_pool)+ab.balance AS liquidity,
-      COALESCE(
-        CASE 
-          WHEN p.id IS NOT NULL THEN p.volume
-          WHEN np.id IS NOT NULL THEN m.volume
-        END,
-        0
-      ) as volume
+      COALESCE(m.volume, 0) as volume
     FROM
       market m
     JOIN
@@ -252,7 +246,6 @@ export const totalLiquidityAndVolume = () => `
       m.market_id,
       m.volume,
       p.id,
-      CASE WHEN p.id IS NOT NULL THEN p.volume END,
       np.id,
       ab.balance
   ) AS market_stats;

--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -225,21 +225,22 @@ export const totalLiquidityAndVolume = () => `
     SELECT
       m.market_id,
       SUM(a.price*a.amount_in_pool)+ab.balance AS liquidity,
-      m.volume
+      COALESCE(p.volume, m.volume) as volume
     FROM
       market m
     JOIN
       asset a ON a.asset_id = ANY (m.outcome_assets)
-    JOIN
+    LEFT JOIN
       pool p ON p.id = m.pool_id
     JOIN
-      account_balance ab ON ab.account_id = p.account_id
+      account_balance ab ON ab.account_id = COALESCE(p.account_id, m.account_id)
     WHERE
       ab.asset_id NOT LIKE '%Outcome%'
       AND ab.balance > 0
     GROUP BY
       m.market_id,
       ab.balance,
+      p.volume,
       m.volume
   ) AS market_stats;
 `;

--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -226,7 +226,7 @@ export const totalLiquidityAndVolume = () => `
       m.market_id,
       SUM(a.price*a.amount_in_pool)+ab.balance AS liquidity,
       CASE 
-        WHEN p.id IS NOT NULL THEN p.volume
+        WHEN p.id IS NOT NULL THEN (SELECT volume FROM pool WHERE id = m.pool_id)
         WHEN np.id IS NOT NULL THEN m.volume
       END as volume
     FROM
@@ -249,9 +249,7 @@ export const totalLiquidityAndVolume = () => `
       m.market_id,
       m.volume,
       p.id,
-      p.volume,
       np.id,
-      np.volume,
       ab.balance
   ) AS market_stats;
 `;

--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -218,54 +218,36 @@ export const marketVolume = (ids: number[], prices: Map<BaseAsset, number>) => `
 `;
 
 export const totalLiquidityAndVolume = () => `
-  WITH pool_stats AS (
+  SELECT
+    ROUND(SUM(liquidity),0) AS total_liquidity,
+    SUM(volume) AS total_volume
+  FROM (
     SELECT
       m.market_id,
-      SUM(a.price * a.amount_in_pool) + ab.balance AS liquidity,
-      p.volume
+      SUM(a.price*a.amount_in_pool)+ab.balance AS liquidity,
+      COALESCE(p.volume, np.volume, 0) as volume
     FROM
       market m
     JOIN
       asset a ON a.asset_id = ANY (m.outcome_assets)
-    JOIN
+    LEFT JOIN
       pool p ON p.id = m.pool_id
-    JOIN
-      account_balance ab ON ab.account_id = p.account_id
+    LEFT JOIN
+      neo_pool np ON np.id = m.neo_pool_id
+    LEFT JOIN
+      account_balance ab ON (
+        (p.id IS NOT NULL AND ab.account_id = p.account_id) OR
+        (np.id IS NOT NULL AND ab.account_id = np.account_id)
+      )
     WHERE
       ab.asset_id NOT LIKE '%Outcome%'
       AND ab.balance > 0
     GROUP BY
       m.market_id,
       ab.balance,
-      p.volume
-  ),
-  neo_pool_stats AS (
-    SELECT
-      m.market_id,
-      SUM(a.price * ab.balance) AS liquidity,
-      m.volume
-    FROM
-      market m
-    JOIN
-      asset a ON a.asset_id = ANY (m.outcome_assets)
-    JOIN
-      neo_pool np ON np.id = m.neo_pool_id
-    JOIN
-      account_balance ab ON ab.account_id = np.account_id
-    WHERE
-      ab.asset_id LIKE '%Outcome%'
-    GROUP BY
-      m.market_id,
-      m.volume
-  )
-  SELECT
-    ROUND(SUM(liquidity), 0) AS total_liquidity,
-    SUM(volume) AS total_volume
-  FROM (
-    SELECT * FROM pool_stats
-    UNION ALL
-    SELECT * FROM neo_pool_stats
-  ) AS combined_stats;
+      p.volume,
+      np.volume
+  ) AS market_stats;
 `;
 
 export const totalMintedInCourt = () => `

--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -225,10 +225,13 @@ export const totalLiquidityAndVolume = () => `
     SELECT
       m.market_id,
       SUM(a.price*a.amount_in_pool)+ab.balance AS liquidity,
-      CASE 
-        WHEN p.id IS NOT NULL THEN (SELECT volume FROM pool WHERE id = m.pool_id)
-        WHEN np.id IS NOT NULL THEN m.volume
-      END as volume
+      COALESCE(
+        CASE 
+          WHEN p.id IS NOT NULL THEN p.volume
+          WHEN np.id IS NOT NULL THEN m.volume
+        END,
+        0
+      ) as volume
     FROM
       market m
     JOIN
@@ -249,6 +252,7 @@ export const totalLiquidityAndVolume = () => `
       m.market_id,
       m.volume,
       p.id,
+      CASE WHEN p.id IS NOT NULL THEN p.volume END,
       np.id,
       ab.balance
   ) AS market_stats;

--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -225,7 +225,11 @@ export const totalLiquidityAndVolume = () => `
     SELECT
       m.market_id,
       SUM(a.price*a.amount_in_pool)+ab.balance AS liquidity,
-      COALESCE(p.volume, np.volume, 0) as volume
+      COALESCE(
+        (SELECT volume FROM pool WHERE id = m.pool_id),
+        (SELECT volume FROM neo_pool WHERE id = m.neo_pool_id),
+        0
+      ) as volume
     FROM
       market m
     JOIN
@@ -244,9 +248,7 @@ export const totalLiquidityAndVolume = () => `
       AND ab.balance > 0
     GROUP BY
       m.market_id,
-      ab.balance,
-      p.volume,
-      np.volume
+      ab.balance
   ) AS market_stats;
 `;
 

--- a/src/server-extension/query.ts
+++ b/src/server-extension/query.ts
@@ -219,10 +219,11 @@ export const marketVolume = (ids: number[], prices: Map<BaseAsset, number>) => `
 
 export const totalLiquidityAndVolume = () => `
   WITH pool_stats AS (
+    -- Traditional pools
     SELECT
       m.market_id,
-      COALESCE(SUM(COALESCE(a.price, 1) * ab.balance), 0) AS liquidity,
-      COALESCE(p.volume, 0) AS volume
+      COALESCE(SUM(COALESCE(a.price, 1) * ab.balance), 0) as liquidity,
+      COALESCE(p.volume, 0) as volume
     FROM
       market m
     LEFT JOIN pool p ON p.id = m.pool_id
@@ -230,28 +231,26 @@ export const totalLiquidityAndVolume = () => `
     LEFT JOIN asset a ON a.market_id = m.id AND a.asset_id = ab.asset_id
     WHERE p.id IS NOT NULL
     GROUP BY m.market_id, p.volume
-  ),
-  neo_pool_stats AS (
+    
+    UNION ALL
+    
+    -- Neo pools
     SELECT
       m.market_id,
-      COALESCE(SUM(a.price * ab.balance), 0) AS liquidity,
-      0 AS volume
+      COALESCE(SUM(a.price * ab.balance), 0) as liquidity,
+      COALESCE(np.volume, 0) as volume
     FROM
       market m
     LEFT JOIN neo_pool np ON np.id = m.neo_pool_id
     LEFT JOIN asset a ON a.market_id = m.id
     LEFT JOIN account_balance ab ON ab.account_id = np.account_id AND ab.asset_id = a.asset_id
     WHERE np.id IS NOT NULL AND a.asset_id ILIKE '%OUTCOME%'
-    GROUP BY m.market_id
+    GROUP BY m.market_id, np.volume
   )
   SELECT
     ROUND(SUM(liquidity), 0) AS total_liquidity,
     SUM(volume) AS total_volume
-  FROM (
-    SELECT * FROM pool_stats
-    UNION ALL
-    SELECT * FROM neo_pool_stats
-  ) AS combined_stats;
+  FROM pool_stats;
 `;
 
 export const totalMintedInCourt = () => `


### PR DESCRIPTION
Old pool doesn't exist for the new markets and implement new schema changes -
1. Volume should be picked from market schema
2. New pool balances should be used while calculating liquidity