### PR TITLE
fix: add poolid to decode in regular neoswap pool deploy events

### DIFF
--- a/src/mappings/neo-swaps/decode.ts
+++ b/src/mappings/neo-swaps/decode.ts
@@ -221,6 +221,7 @@ export const decodePoolDeployedEvent = (event: Event): PoolDeployedEvent => {
     liquidityParameter: bigint;
     poolSharesAmount: bigint;
     swapFee: bigint;
+    poolId?: bigint;
   };
   if (events.neoSwaps.poolDeployed.v50.is(event)) {
     decoded = events.neoSwaps.poolDeployed.v50.decode(event) as any;
@@ -242,6 +243,7 @@ export const decodePoolDeployedEvent = (event: Event): PoolDeployedEvent => {
     liquidityParameter: BigInt(decoded.liquidityParameter),
     poolSharesAmount: BigInt(decoded.poolSharesAmount),
     swapFee: BigInt(decoded.swapFee),
+    poolId: decoded.poolId ? Number(decoded.poolId) : Number(decoded.marketId), // Using marketId as poolId for v50-v54 to ensure uniqueness
   };
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pool deployment events now include a poolId. For older versions, poolId is backfilled to maintain uniqueness.

* **Bug Fixes**
  * Ensures consistent, collision-free pool identification across versions by replacing legacy heuristics.

* **Refactor**
  * Standardized identifiers to use poolId for pools and liquidity share managers.
  * Removed legacy block-height fallback and extraneous debug logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->