### PR TITLE
Combi Pools Updates: stats, price history, market ids

### DIFF
--- a/db/migrations/1757105549470-Data.js
+++ b/db/migrations/1757105549470-Data.js
@@ -1,0 +1,13 @@
+module.exports = class Data1757105549470 {
+    name = 'Data1757105549470'
+
+    async up(db) {
+        await db.query(`ALTER TABLE "neo_pool" ADD "market_ids" integer array`)
+        await db.query(`UPDATE "neo_pool" SET "market_ids" = ARRAY["market_id"] WHERE "market_ids" IS NULL`)
+        await db.query(`ALTER TABLE "neo_pool" ALTER COLUMN "market_ids" SET NOT NULL`)
+    }
+
+    async down(db) {
+        await db.query(`ALTER TABLE "neo_pool" DROP COLUMN "market_ids"`)
+    }
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -307,6 +307,7 @@ type NeoPool @entity {
   liquidityParameter: BigInt!
   liquiditySharesManager: [LiquiditySharesManager!]! @derivedFrom(field: "neoPool")
   marketId: Int! @index
+  marketIds: [Int!]!
   poolId: Int! @index
   swapFee: BigInt!
   totalStake: BigInt!

--- a/src/mappings/neo-swaps/decode.ts
+++ b/src/mappings/neo-swaps/decode.ts
@@ -76,7 +76,8 @@ export const decodeCombinatorialPoolDeployed = (event: Event): PoolDeployedEvent
   }
   return {
     who: ss58.encode({ prefix: 73, bytes: decoded.who }),
-    marketId: Number(decoded.marketIds[0]),
+    marketId: Number(decoded.marketIds[0]), // Use first market ID for database compatibility
+    marketIds: decoded.marketIds.map(id => Number(id)), // Store all market IDs for reference
     poolId: Number(decoded.poolId),
     accountId: ss58.encode({ prefix: 73, bytes: decoded.accountId }),
     collateral: formatAssetId(decoded.collateral),
@@ -238,6 +239,7 @@ export const decodePoolDeployedEvent = (event: Event): PoolDeployedEvent => {
   return {
     who: ss58.encode({ prefix: 73, bytes: decoded.who }),
     marketId: Number(decoded.marketId),
+    marketIds: [Number(decoded.marketId)], // Single market ID as array for regular pools
     accountId: ss58.encode({ prefix: 73, bytes: decoded.accountId }),
     collateral: formatAssetId(decoded.collateral),
     liquidityParameter: BigInt(decoded.liquidityParameter),
@@ -334,7 +336,8 @@ interface JoinExitExecutedEvent {
 
 interface PoolDeployedEvent {
   who: string;
-  marketId: number;
+  marketId: number;        // First market ID for database compatibility
+  marketIds: number[];     // All market IDs for combo pools
   poolId?: number;
   accountId: string;
   collateral: string;

--- a/src/model/generated/neoPool.model.ts
+++ b/src/model/generated/neoPool.model.ts
@@ -34,6 +34,9 @@ export class NeoPool {
     @IntColumn_({nullable: false})
     marketId!: number
 
+    @IntColumn_({array: true, nullable: false})
+    marketIds!: (number)[]
+
     @Index_()
     @IntColumn_({nullable: false})
     poolId!: number

--- a/src/server-extension/resolvers/index.ts
+++ b/src/server-extension/resolvers/index.ts
@@ -7,6 +7,7 @@ import { LiquidityHistoryResolver } from './liquidityHistory';
 import { MarketMetadataResolver } from './marketMetadata';
 import { MarketStatsResolver } from './marketStats';
 import { MarketStatsWithOrderResolver } from './marketStatsWithOrder';
+import { PoolStatsResolver } from './poolStats';
 import { PriceHistoryResolver } from './priceHistory';
 import { StatsResolver } from './stats';
 import { VolumeHistoryResolver } from './volumeHistory';
@@ -47,6 +48,7 @@ export {
   MarketMetadataResolver,
   MarketStatsResolver,
   MarketStatsWithOrderResolver,
+  PoolStatsResolver,
   PriceHistoryResolver,
   StatsResolver,
   VolumeHistoryResolver,

--- a/src/server-extension/resolvers/poolStats.ts
+++ b/src/server-extension/resolvers/poolStats.ts
@@ -1,0 +1,45 @@
+import { Arg, Field, Int, ObjectType, Query, Resolver } from 'type-graphql';
+import type { EntityManager } from 'typeorm';
+import { getAssetUsdPrices, mergeByField } from '../helper';
+import { poolLiquidity, poolParticipants, poolTraders, poolVolume } from '../query';
+
+@ObjectType()
+export class PoolStats {
+  @Field(() => Int, { name: 'poolId' })
+  pool_id!: number;
+
+  @Field(() => Int)
+  participants!: number;
+
+  @Field(() => BigInt)
+  liquidity!: bigint;
+
+  @Field(() => Int)
+  traders!: number;
+
+  @Field(() => BigInt)
+  volume!: bigint;
+
+  constructor(props: Partial<PoolStats>) {
+    Object.assign(this, props);
+  }
+}
+
+@Resolver()
+export class PoolStatsResolver {
+  constructor(private tx: () => Promise<EntityManager>) {}
+
+  @Query(() => [PoolStats])
+  async poolStats(@Arg('poolId', () => [Int!], { nullable: false }) ids: number[]): Promise<PoolStats[]> {
+    const manager = await this.tx();
+    const participants = await manager.query(poolParticipants(ids));
+    const liquidity = await manager.query(poolLiquidity(ids));
+    const traders = await manager.query(poolTraders(ids));
+    const volume = await manager.query(poolVolume(ids, await getAssetUsdPrices()));
+
+    const merged1 = mergeByField(liquidity, volume, 'pool_id');
+    const merged2 = mergeByField(traders, participants, 'pool_id');
+    const result = mergeByField(merged1, merged2, 'pool_id');
+    return result;
+  }
+}

--- a/src/server-extension/resolvers/priceHistory.ts
+++ b/src/server-extension/resolvers/priceHistory.ts
@@ -1,7 +1,7 @@
 import { Field, Int, ObjectType, Query, Resolver, InputType, Arg } from 'type-graphql';
 import { EntityManager } from 'typeorm';
 import { Unit } from '../../consts';
-import { assetPriceHistory, marketInfo } from '../query';
+import { assetPriceHistory, marketInfo, comboPoolAssets } from '../query';
 
 
 @ObjectType()
@@ -81,6 +81,63 @@ export class PriceHistoryResolver {
     interval = interval ?? new IntervalArgs({ unit: Unit.Hour, value: 1 });
 
     // Get normalized price history for all assets at once
+    const priceHistoryRows = await manager.query(
+      assetPriceHistory(outcomeAssets, startTime, endTime, interval.toString())
+    );
+
+    // Group by timestamp and build response format
+    const timestampGroups = new Map<string, any[]>();
+    
+    priceHistoryRows.forEach((row: any) => {
+      const timestamp = row.timestamp.toISOString();
+      if (!timestampGroups.has(timestamp)) {
+        timestampGroups.set(timestamp, []);
+      }
+      
+      if (row.asset_id && row.new_price !== null) {
+        timestampGroups.get(timestamp)!.push({
+          assetId: row.asset_id,
+          price: row.new_price,
+        });
+      }
+    });
+
+    // Transform to expected response format
+    return Array.from(timestampGroups.entries()).map(([timestamp, prices]) => ({
+      timestamp: new Date(timestamp),
+      prices,
+    }));
+  }
+
+  @Query(() => [PriceHistory], { nullable: true })
+  async priceHistoryByPoolId(
+    @Arg('poolId', () => Int, { nullable: false }) poolId: number,
+    @Arg('startTime', () => String, { nullable: true }) startTime: string,
+    @Arg('endTime', () => String, { nullable: true }) endTime: string,
+    @Arg('interval', () => IntervalArgs, { nullable: true }) interval: IntervalArgs
+  ): Promise<PriceHistory[] | undefined> {
+    const manager = await this.tx();
+    
+    // Get combinatorial assets from pool's account balances
+    const poolResult = await manager.query(comboPoolAssets(poolId));
+    if (!poolResult || poolResult.length === 0) return;
+    
+    const outcomeAssets = poolResult[0].outcome_assets;
+    if (!outcomeAssets || outcomeAssets.length === 0) return;
+
+    // Set default time range if not provided
+    if (!endTime) {
+      endTime = new Date().toISOString();
+    }
+    if (!startTime) {
+      // Default to 24 hours ago
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      startTime = yesterday.toISOString();
+    }
+    interval = interval ?? new IntervalArgs({ unit: Unit.Hour, value: 1 });
+
+    // Get normalized price history for all combinatorial assets at once
     const priceHistoryRows = await manager.query(
       assetPriceHistory(outcomeAssets, startTime, endTime, interval.toString())
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * NeoPool exposes marketIds to represent multiple associated markets; primary marketId remains for compatibility.
  * Added poolStats query returning per-pool participants, liquidity, traders, and volume.
  * Added priceHistoryByPoolId query to fetch normalized price history for a pool’s assets with time range and interval options.

* Database
  * Migration to store multiple market IDs per pool, initialized from existing data and enforced as non-null arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->